### PR TITLE
Refine license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ so clients and intermediate caches decide their own policies.
 If you need custom caching semantics, wrap the file server handler with your own
 `http.Handler` that sets `Cache-Control`, `ETag`, or other headers before
 forwarding the request to the embedded `http.FileServer` instance.
+
+## License
+This project is distributed under the terms of the [MIT License](./LICENSE).
+Copyright (c) 2025 Vadym Tyemirov. Refer to the license file for the complete text, including permissions and limitations.


### PR DESCRIPTION
## Summary
- clarify the README license section to explicitly reference the MIT License file and copyright notice for Vadym Tyemirov

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cdfbdf72a48327a3cc64aca8ea0f5a