### PR TITLE
Improve serving address logging

### DIFF
--- a/internal/serverdetails/address_formatter.go
+++ b/internal/serverdetails/address_formatter.go
@@ -1,0 +1,36 @@
+// Package serverdetails provides utilities for describing server configuration
+// details in a user-friendly format.
+package serverdetails
+
+import (
+	"net"
+	"strings"
+)
+
+const (
+	bindAddressEmptyValue            = ""
+	ipv4AddressAnyValue              = "0.0.0.0"
+	ipv4AddressLoopbackValue         = "127.0.0.1"
+	loggingDisplayHostLocalhostValue = "localhost"
+)
+
+// ServingAddressFormatter normalizes listening addresses for presentation in
+// logs so that users can click the reported URL directly.
+type ServingAddressFormatter struct{}
+
+// NewServingAddressFormatter constructs a ServingAddressFormatter.
+func NewServingAddressFormatter() ServingAddressFormatter {
+	return ServingAddressFormatter{}
+}
+
+// FormatHostAndPortForLogging returns the host and port combination to display
+// in logs. Any empty, wildcard, or loopback bind addresses are mapped to the
+// more user-friendly "localhost" value.
+func (formatter ServingAddressFormatter) FormatHostAndPortForLogging(bindAddress string, port string) string {
+	sanitizedHost := strings.TrimSpace(bindAddress)
+	switch sanitizedHost {
+	case bindAddressEmptyValue, ipv4AddressAnyValue, ipv4AddressLoopbackValue:
+		sanitizedHost = loggingDisplayHostLocalhostValue
+	}
+	return net.JoinHostPort(sanitizedHost, port)
+}

--- a/internal/serverdetails/address_formatter_test.go
+++ b/internal/serverdetails/address_formatter_test.go
@@ -1,0 +1,82 @@
+package serverdetails_test
+
+import (
+	"testing"
+
+	"github.com/temirov/ghhtp/internal/serverdetails"
+)
+
+const (
+	testNameEmptyBindAddress              = "empty bind address becomes localhost"
+	testNameWildcardBindAddress           = "wildcard bind address becomes localhost"
+	testNameLoopbackBindAddress           = "loopback bind address becomes localhost"
+	testNameExternalBindAddressPreserved  = "external bind address is preserved"
+	testNameHostnameWithWhitespaceTrimmed = "hostname with whitespace is trimmed"
+	bindAddressEmptyValue                 = ""
+	bindAddressWildcardValue              = "0.0.0.0"
+	bindAddressLoopbackValue              = "127.0.0.1"
+	bindAddressExternalValue              = "192.168.10.50"
+	bindAddressHostnameWithWhitespace     = "  example.com  "
+	bindAddressIpvSixValue                = "2001:db8::1"
+	portValue                             = "8000"
+	expectedLocalhostDisplay              = "localhost:8000"
+	expectedExternalDisplay               = "192.168.10.50:8000"
+	expectedHostnameDisplay               = "example.com:8000"
+)
+
+func TestServingAddressFormatter_FormatHostAndPortForLogging(t *testing.T) {
+	formatter := serverdetails.NewServingAddressFormatter()
+
+	testCases := []struct {
+		name        string
+		bindAddress string
+		expected    string
+	}{
+		{
+			name:        testNameEmptyBindAddress,
+			bindAddress: bindAddressEmptyValue,
+			expected:    expectedLocalhostDisplay,
+		},
+		{
+			name:        testNameWildcardBindAddress,
+			bindAddress: bindAddressWildcardValue,
+			expected:    expectedLocalhostDisplay,
+		},
+		{
+			name:        testNameLoopbackBindAddress,
+			bindAddress: bindAddressLoopbackValue,
+			expected:    expectedLocalhostDisplay,
+		},
+		{
+			name:        testNameExternalBindAddressPreserved,
+			bindAddress: bindAddressExternalValue,
+			expected:    expectedExternalDisplay,
+		},
+		{
+			name:        testNameHostnameWithWhitespaceTrimmed,
+			bindAddress: bindAddressHostnameWithWhitespace,
+			expected:    expectedHostnameDisplay,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testCase := testCase
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			actual := formatter.FormatHostAndPortForLogging(testCase.bindAddress, portValue)
+			if actual != testCase.expected {
+				t.Fatalf("formatted address mismatch: expected %s, got %s", testCase.expected, actual)
+			}
+		})
+	}
+}
+
+func TestServingAddressFormatter_FormatHostAndPortForLoggingUsesNetJoinHostPort(t *testing.T) {
+	formatter := serverdetails.NewServingAddressFormatter()
+	expectedAddress := "[2001:db8::1]:8000"
+
+	actualAddress := formatter.FormatHostAndPortForLogging(bindAddressIpvSixValue, portValue)
+	if actualAddress != expectedAddress {
+		t.Fatalf("expected IPv6 address to remain bracketed: expected %s, got %s", expectedAddress, actualAddress)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/temirov/ghhtp/internal/serverdetails"
 )
 
 const (
@@ -137,6 +139,8 @@ func main() {
 	})
 
 	listenAddress := net.JoinHostPort(bindAddressFlag, portString)
+	servingAddressFormatter := serverdetails.NewServingAddressFormatter()
+	displayAddress := servingAddressFormatter.FormatHostAndPortForLogging(bindAddressFlag, portString)
 
 	httpServer := &http.Server{
 		Addr:              listenAddress,
@@ -155,9 +159,9 @@ func main() {
 	log.SetFlags(0)
 	nowString := time.Now().Format(logTimeLayout)
 	if tlsCertificatePathFlag == "" {
-		log.Printf(logMessageServingHttp, nowString, absoluteDirectoryPath, listenAddress, normalizedProtocol)
+		log.Printf(logMessageServingHttp, nowString, absoluteDirectoryPath, displayAddress, normalizedProtocol)
 	} else {
-		log.Printf(logMessageServingHttps, nowString, absoluteDirectoryPath, listenAddress, normalizedProtocol)
+		log.Printf(logMessageServingHttps, nowString, absoluteDirectoryPath, displayAddress, normalizedProtocol)
 	}
 
 	terminationSignals := make(chan os.Signal, 1)


### PR DESCRIPTION
## Summary
- add a serverdetails.ServingAddressFormatter helper to normalize bind addresses for display
- use the formatter so HTTP/S logs report clickable localhost URLs when binding to wildcard or loopback
- cover the formatter behaviour with table-driven tests

## Testing
- GOTOOLCHAIN=local go test ./... *(fails: go.mod requires go >= 1.24.6 while toolchain is 1.24.3)*

------
https://chatgpt.com/codex/tasks/task_e_68e600625f108327884b773ce94ec18d