### PR TITLE
chore(ghttp): ensure gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,8 @@ bin/
 .vscode/
 
 PLAN.md
+# Managed by gix gitignore workflow
+.env.*
+.DS_Store
+qodana.yaml
+tools/


### PR DESCRIPTION
Ensure `.gitignore` contains the standard secrets/tooling entries (.env, tools/, bin/).