### PR TITLE
refactor(ghttp): rewrite module namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gHTTP
 
-[![GitHub release](https://img.shields.io/github/release/temirov/ghttp.svg)](https://github.com/temirov/ghttp/releases)
+[![GitHub release](https://img.shields.io/github/release/tyemirov/ghttp.svg)](https://github.com/tyemirov/ghttp/releases)
 
 gHTTP is a Go-powered file server that mirrors the ergonomics of `python -m http.server`, adds structured zap-based request logging, renders mardown files as HTML, and provisions self-signed HTTPS certificates for local development.
 
@@ -13,30 +13,30 @@ gHTTP is a Go-powered file server that mirrors the ergonomics of `python -m http
 Pull and run the latest Docker image:
 
 ```bash
-docker pull ghcr.io/temirov/ghttp:latest
-docker run -p 8080:8080 -v $(pwd):/data ghcr.io/temirov/ghttp:latest --directory /data
+docker pull ghcr.io/tyemirov/ghttp:latest
+docker run -p 8080:8080 -v $(pwd):/data ghcr.io/tyemirov/ghttp:latest --directory /data
 ```
 
 Custom port and directory examples:
 
 ```bash
 # Serve current directory on port 9000
-docker run -p 9000:9000 -v $(pwd):/data ghcr.io/temirov/ghttp:latest --directory /data 9000
+docker run -p 9000:9000 -v $(pwd):/data ghcr.io/tyemirov/ghttp:latest --directory /data 9000
 
 # Serve with HTTPS (requires certificate setup)
-docker run -p 8443:8443 -v $(pwd):/data -v ~/.config/ghttp:/root/.config/ghttp ghcr.io/temirov/ghttp:latest --directory /data --https 8443
+docker run -p 8443:8443 -v $(pwd):/data -v ~/.config/ghttp:/root/.config/ghttp ghcr.io/tyemirov/ghttp:latest --directory /data --https 8443
 ```
 
 ### Releases
 
-Download the latest binaries from the [Releases page](https://github.com/temirov/ghttp/releases).
+Download the latest binaries from the [Releases page](https://github.com/tyemirov/ghttp/releases).
 
 ### Go toolchain
 
 Install gHTTP with the Go toolchain:
 
 ```
-go install github.com/temirov/ghttp/cmd/ghttp@latest
+go install github.com/tyemirov/ghttp/cmd/ghttp@latest
 ```
 
 Go 1.24.6 or newer is required, matching the minimum version declared in `go.mod`.

--- a/cmd/ghttp/main.go
+++ b/cmd/ghttp/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"os"
 
-	"github.com/temirov/ghttp/internal/app"
+	"github.com/tyemirov/ghttp/internal/app"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/temirov/ghttp
+module github.com/tyemirov/ghttp
 
 go 1.24.6
 

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/viper"
 
-	"github.com/temirov/ghttp/internal/certificates"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/certificates"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 type contextKey string

--- a/internal/app/https_commands.go
+++ b/internal/app/https_commands.go
@@ -16,11 +16,11 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/temirov/ghttp/internal/certificates"
-	"github.com/temirov/ghttp/internal/certificates/truststore"
-	"github.com/temirov/ghttp/internal/server"
-	"github.com/temirov/ghttp/internal/serverdetails"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/certificates"
+	"github.com/tyemirov/ghttp/internal/certificates/truststore"
+	"github.com/tyemirov/ghttp/internal/server"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 const (

--- a/internal/app/root_command_test.go
+++ b/internal/app/root_command_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 func TestNewRootCommandProvidesHTTPSFlagOnce(t *testing.T) {

--- a/internal/app/serve_command.go
+++ b/internal/app/serve_command.go
@@ -14,9 +14,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/temirov/ghttp/internal/server"
-	"github.com/temirov/ghttp/internal/serverdetails"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/server"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 const (

--- a/internal/app/serve_command_test.go
+++ b/internal/app/serve_command_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 func TestPrepareServeConfigurationRejectsHTTPSWithTLSFiles(t *testing.T) {

--- a/internal/certificates/truststore/firefox_integration.go
+++ b/internal/certificates/truststore/firefox_integration.go
@@ -11,7 +11,7 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/temirov/ghttp/internal/certificates"
+	"github.com/tyemirov/ghttp/internal/certificates"
 )
 
 const (

--- a/internal/certificates/truststore/installer.go
+++ b/internal/certificates/truststore/installer.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/temirov/ghttp/internal/certificates"
+	"github.com/tyemirov/ghttp/internal/certificates"
 )
 
 const (

--- a/internal/certificates/truststore/installer_test.go
+++ b/internal/certificates/truststore/installer_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/temirov/ghttp/internal/certificates"
+	"github.com/tyemirov/ghttp/internal/certificates"
 )
 
 type executedCommand struct {

--- a/internal/server/file_server.go
+++ b/internal/server/file_server.go
@@ -13,8 +13,8 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/temirov/ghttp/internal/serverdetails"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 const (

--- a/internal/server/file_server_mime_test.go
+++ b/internal/server/file_server_mime_test.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/temirov/ghttp/internal/server"
-	"github.com/temirov/ghttp/internal/serverdetails"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/server"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 const (

--- a/internal/server/file_server_port_test.go
+++ b/internal/server/file_server_port_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/temirov/ghttp/internal/serverdetails"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 func TestIntegrationFileServerReturnsFriendlyErrorWhenPortInUse(t *testing.T) {

--- a/internal/server/file_server_test.go
+++ b/internal/server/file_server_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/temirov/ghttp/internal/serverdetails"
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 func TestIntegrationFileServerServesMarkdownAsHTML(t *testing.T) {

--- a/internal/server/markdown_handler.go
+++ b/internal/server/markdown_handler.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/temirov/ghttp/internal/markdown"
+	"github.com/tyemirov/ghttp/internal/markdown"
 )
 
 var directoryIndexCandidates = []string{"index.html", "index.htm"}

--- a/internal/serverdetails/address_formatter_test.go
+++ b/internal/serverdetails/address_formatter_test.go
@@ -3,7 +3,7 @@ package serverdetails_test
 import (
 	"testing"
 
-	"github.com/temirov/ghttp/internal/serverdetails"
+	"github.com/tyemirov/ghttp/internal/serverdetails"
 )
 
 const (

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
-	"github.com/temirov/ghttp/pkg/logging"
+	"github.com/tyemirov/ghttp/pkg/logging"
 )
 
 const (


### PR DESCRIPTION
Rewrites Go module imports from `github.com/temirov` to `github.com/tyemirov` after the owner rename.