### PR TITLE
feat: add reverse proxy with WebSocket support (#100)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -4,6 +4,25 @@ Entries record newly discovered requests or changes, with their outcomes. No ins
 
 ## Features (100–199)
 
+### 100: Reverse proxy with WebSocket support
+**Status:** Done
+
+Add reverse proxy capability to ghttp with full WebSocket support. This enables ghttp to serve static files while proxying API requests (including WebSocket connections) to a backend server.
+
+**Configuration:**
+- `GHTTP_SERVE_PROXY_BACKEND` - Backend URL (e.g., `http://backend:8001`)
+- `GHTTP_SERVE_PROXY_PATH_PREFIX` - Path prefix to proxy (e.g., `/api/`)
+
+Or via flags:
+- `--proxy-backend` - Backend URL to proxy requests to
+- `--proxy-path` - Path prefix to proxy
+
+**Implementation:**
+- Proxy handler with automatic WebSocket upgrade detection
+- HTTP reverse proxy using httputil.ReverseProxy
+- WebSocket proxying via TCP connection hijacking
+- Falls back to static file serving for non-matching paths
+
 ## Improvements (200–299)
 
 ## BugFixes (300–399)

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/tyemirov/ghttp
 go 1.25.4
 
 require (
+	github.com/gorilla/websocket v1.5.3
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
-	github.com/temirov/ghttp v0.2.4
 	github.com/yuin/goldmark v1.7.13
 	go.uber.org/zap v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/go-viper/mapstructure/v2 v2.4.0 h1:EBsztssimR/CONLSZZ04E8qAkxNYq4Qp9L
 github.com/go-viper/mapstructure/v2 v2.4.0/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -39,8 +41,6 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/temirov/ghttp v0.2.4 h1:80Or9MTKu/rXI5XszXbTBcu1xLtrGIFZkk1ooeIz2dc=
-github.com/temirov/ghttp v0.2.4/go.mod h1:zfcjHQ+UqU7zVzcwxUoiQR4G8i/Y7Rv+7pYVggbYJUs=
 github.com/yuin/goldmark v1.7.13 h1:GPddIs617DnBLFFVJFgpo1aBfe/4xcvMc3SB5t/D0pA=
 github.com/yuin/goldmark v1.7.13/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -40,6 +40,8 @@ const (
 	flagNameLoggingType        = "logging-type"
 	flagNameCertificateDir     = "cert-dir"
 	flagNameHTTPSHosts         = "host"
+	flagNameProxyBackend       = "proxy-backend"
+	flagNameProxyPathPrefix    = "proxy-path"
 
 	configKeyServeBindAddress        = "serve.bind_address"
 	configKeyServeDirectory          = "serve.directory"
@@ -54,6 +56,8 @@ const (
 	configKeyHTTPSCertificateDir     = "https.certificate_directory"
 	configKeyHTTPSHosts              = "https.hosts"
 	configKeyHTTPSPort               = "https.port"
+	configKeyProxyBackend            = "serve.proxy_backend"
+	configKeyProxyPathPrefix         = "serve.proxy_path_prefix"
 
 	logMessageFailedInitializeLogger = "failed to initialize logger"
 	logMessageResolveUserConfigDir   = "resolve user config directory"
@@ -124,6 +128,8 @@ func Execute(ctx context.Context, arguments []string) int {
 	configurationManager.SetDefault(configKeyHTTPSCertificateDir, filepath.Join(applicationConfigDir, certificates.DefaultCertificateDirectoryName))
 	configurationManager.SetDefault(configKeyHTTPSHosts, []string{"localhost", "127.0.0.1", "::1"})
 	configurationManager.SetDefault(configKeyHTTPSPort, defaultHTTPSServePort)
+	configurationManager.SetDefault(configKeyProxyBackend, "")
+	configurationManager.SetDefault(configKeyProxyPathPrefix, "")
 	resources := &applicationResources{
 		configurationManager: configurationManager,
 		loggingService:       initialService,

--- a/internal/app/root_command.go
+++ b/internal/app/root_command.go
@@ -53,12 +53,16 @@ func configureServeFlags(flagSet *pflag.FlagSet, configurationManager *viper.Vip
 	flagSet.Bool(flagNameNoMarkdown, configurationManager.GetBool(configKeyServeNoMarkdown), "Disable Markdown rendering")
 	flagSet.Bool(flagNameBrowse, configurationManager.GetBool(configKeyServeBrowse), "Browse directories without automatic rendering")
 	flagSet.String(flagNameLoggingType, configurationManager.GetString(configKeyServeLoggingType), "Logging type (CONSOLE or JSON)")
+	flagSet.String(flagNameProxyBackend, configurationManager.GetString(configKeyProxyBackend), "Backend URL to proxy requests to (e.g., http://backend:8001)")
+	flagSet.String(flagNameProxyPathPrefix, configurationManager.GetString(configKeyProxyPathPrefix), "Path prefix to proxy (e.g., /api/)")
 	_ = configurationManager.BindPFlag(configKeyServeBindAddress, flagSet.Lookup(flagNameBindAddress))
 	_ = configurationManager.BindPFlag(configKeyServeDirectory, flagSet.Lookup(flagNameDirectory))
 	_ = configurationManager.BindPFlag(configKeyServeProtocol, flagSet.Lookup(flagNameProtocol))
 	_ = configurationManager.BindPFlag(configKeyServeNoMarkdown, flagSet.Lookup(flagNameNoMarkdown))
 	_ = configurationManager.BindPFlag(configKeyServeBrowse, flagSet.Lookup(flagNameBrowse))
 	_ = configurationManager.BindPFlag(configKeyServeLoggingType, flagSet.Lookup(flagNameLoggingType))
+	_ = configurationManager.BindPFlag(configKeyProxyBackend, flagSet.Lookup(flagNameProxyBackend))
+	_ = configurationManager.BindPFlag(configKeyProxyPathPrefix, flagSet.Lookup(flagNameProxyPathPrefix))
 }
 
 func configureServeHTTPSOptions(flagSet *pflag.FlagSet, configurationManager *viper.Viper) {

--- a/internal/app/serve_command.go
+++ b/internal/app/serve_command.go
@@ -44,6 +44,8 @@ type ServeConfiguration struct {
 	BrowseDirectories       bool
 	InitialFileRelativePath string
 	LoggingType             string
+	ProxyBackendURL         string
+	ProxyPathPrefix         string
 }
 
 func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey string, allowTLSFiles bool) error {
@@ -140,6 +142,10 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 	if browseDirectories {
 		disableDirectoryListing = false
 	}
+
+	proxyBackendURL := strings.TrimSpace(configurationManager.GetString(configKeyProxyBackend))
+	proxyPathPrefix := strings.TrimSpace(configurationManager.GetString(configKeyProxyPathPrefix))
+
 	serveConfiguration := ServeConfiguration{
 		BindAddress:             bindAddress,
 		Port:                    portValue,
@@ -153,6 +159,8 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 		BrowseDirectories:       browseDirectories,
 		InitialFileRelativePath: initialFileRelativePath,
 		LoggingType:             loggingTypeValue,
+		ProxyBackendURL:         proxyBackendURL,
+		ProxyPathPrefix:         proxyPathPrefix,
 	}
 
 	if loggerErr := resources.updateLogger(loggingTypeValue); loggerErr != nil {
@@ -190,6 +198,8 @@ func runServe(cmd *cobra.Command) error {
 		BrowseDirectories:       serveConfiguration.BrowseDirectories,
 		InitialFileRelativePath: serveConfiguration.InitialFileRelativePath,
 		LoggingType:             serveConfiguration.LoggingType,
+		ProxyBackendURL:         serveConfiguration.ProxyBackendURL,
+		ProxyPathPrefix:         serveConfiguration.ProxyPathPrefix,
 	}
 	if serveConfiguration.TLSCertificatePath != "" {
 		fileServerConfiguration.TLS = &server.TLSConfiguration{

--- a/internal/server/file_server.go
+++ b/internal/server/file_server.go
@@ -57,6 +57,8 @@ type FileServerConfiguration struct {
 	InitialFileRelativePath string
 	LoggingType             string
 	TLS                     *TLSConfiguration
+	ProxyBackendURL         string
+	ProxyPathPrefix         string
 }
 
 // TLSConfiguration describes transport layer security configuration.
@@ -185,6 +187,14 @@ func (fileServer FileServer) buildFileHandler(configuration FileServerConfigurat
 	}
 	if configuration.InitialFileRelativePath != "" && !configuration.BrowseDirectories {
 		handler = newInitialFileHandler(handler, configuration.InitialFileRelativePath)
+	}
+	if configuration.ProxyBackendURL != "" && configuration.ProxyPathPrefix != "" {
+		proxyHandler, err := newProxyHandler(handler, configuration.ProxyBackendURL, configuration.ProxyPathPrefix)
+		if err != nil {
+			fileServer.loggingService.Error("failed to create proxy handler", err)
+		} else {
+			handler = proxyHandler
+		}
 	}
 	return handler
 }

--- a/internal/server/proxy_handler.go
+++ b/internal/server/proxy_handler.go
@@ -20,10 +20,10 @@ const (
 )
 
 type proxyHandler struct {
-	next        http.Handler
-	backendURL  *url.URL
-	pathPrefix  string
-	httpProxy   *httputil.ReverseProxy
+	next       http.Handler
+	backendURL *url.URL
+	pathPrefix string
+	httpProxy  *httputil.ReverseProxy
 }
 
 func newProxyHandler(next http.Handler, backendURL string, pathPrefix string) (http.Handler, error) {

--- a/internal/server/proxy_handler.go
+++ b/internal/server/proxy_handler.go
@@ -1,0 +1,153 @@
+package server
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	headerConnection        = "Connection"
+	headerUpgrade           = "Upgrade"
+	headerWebSocketProtocol = "Sec-WebSocket-Protocol"
+	valueUpgrade            = "upgrade"
+	valueWebSocket          = "websocket"
+)
+
+type proxyHandler struct {
+	next        http.Handler
+	backendURL  *url.URL
+	pathPrefix  string
+	httpProxy   *httputil.ReverseProxy
+}
+
+func newProxyHandler(next http.Handler, backendURL string, pathPrefix string) (http.Handler, error) {
+	parsedURL, err := url.Parse(backendURL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := httputil.NewSingleHostReverseProxy(parsedURL)
+	proxy.ErrorHandler = func(w http.ResponseWriter, r *http.Request, err error) {
+		http.Error(w, "Bad Gateway: "+err.Error(), http.StatusBadGateway)
+	}
+
+	return &proxyHandler{
+		next:       next,
+		backendURL: parsedURL,
+		pathPrefix: pathPrefix,
+		httpProxy:  proxy,
+	}, nil
+}
+
+func (h *proxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !strings.HasPrefix(r.URL.Path, h.pathPrefix) {
+		h.next.ServeHTTP(w, r)
+		return
+	}
+
+	if h.isWebSocketUpgrade(r) {
+		h.handleWebSocket(w, r)
+		return
+	}
+
+	h.httpProxy.ServeHTTP(w, r)
+}
+
+func (h *proxyHandler) isWebSocketUpgrade(r *http.Request) bool {
+	connectionHeader := strings.ToLower(r.Header.Get(headerConnection))
+	upgradeHeader := strings.ToLower(r.Header.Get(headerUpgrade))
+	return strings.Contains(connectionHeader, valueUpgrade) && upgradeHeader == valueWebSocket
+}
+
+func (h *proxyHandler) handleWebSocket(w http.ResponseWriter, r *http.Request) {
+	backendHost := h.backendURL.Host
+	scheme := "ws"
+	if h.backendURL.Scheme == "https" {
+		scheme = "wss"
+	}
+
+	backendConn, err := net.DialTimeout("tcp", backendHost, 10*time.Second)
+	if err != nil {
+		http.Error(w, "Bad Gateway: failed to connect to backend", http.StatusBadGateway)
+		return
+	}
+	defer backendConn.Close()
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		http.Error(w, "WebSocket hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, clientBuf, err := hijacker.Hijack()
+	if err != nil {
+		http.Error(w, "Failed to hijack connection", http.StatusInternalServerError)
+		return
+	}
+	defer clientConn.Close()
+
+	backendURL := &url.URL{
+		Scheme:   scheme,
+		Host:     backendHost,
+		Path:     r.URL.Path,
+		RawQuery: r.URL.RawQuery,
+	}
+
+	upgradeReq := &http.Request{
+		Method:     r.Method,
+		URL:        backendURL,
+		Proto:      r.Proto,
+		ProtoMajor: r.ProtoMajor,
+		ProtoMinor: r.ProtoMinor,
+		Header:     cloneHeaders(r.Header),
+		Host:       backendHost,
+	}
+	upgradeReq.Header.Set("Host", backendHost)
+
+	if err := upgradeReq.Write(backendConn); err != nil {
+		return
+	}
+
+	backendBuf := bufio.NewReader(backendConn)
+	resp, err := http.ReadResponse(backendBuf, upgradeReq)
+	if err != nil {
+		return
+	}
+
+	if err := resp.Write(clientConn); err != nil {
+		return
+	}
+
+	done := make(chan struct{}, 2)
+
+	go func() {
+		copyWithBuffer(backendConn, clientBuf)
+		done <- struct{}{}
+	}()
+
+	go func() {
+		copyWithBuffer(clientConn, backendBuf)
+		done <- struct{}{}
+	}()
+
+	<-done
+}
+
+func cloneHeaders(src http.Header) http.Header {
+	dst := make(http.Header, len(src))
+	for k, vv := range src {
+		dst[k] = append([]string(nil), vv...)
+	}
+	return dst
+}
+
+func copyWithBuffer(dst io.Writer, src io.Reader) {
+	buf := make([]byte, 32*1024)
+	io.CopyBuffer(dst, src, buf)
+}

--- a/internal/server/proxy_handler_test.go
+++ b/internal/server/proxy_handler_test.go
@@ -140,10 +140,10 @@ func TestProxyHandlerDetectsWebSocketUpgrade(t *testing.T) {
 	handler := &proxyHandler{}
 
 	tests := []struct {
-		name           string
-		connectionHdr  string
-		upgradeHdr     string
-		expectUpgrade  bool
+		name          string
+		connectionHdr string
+		upgradeHdr    string
+		expectUpgrade bool
 	}{
 		{"websocket upgrade", "Upgrade", "websocket", true},
 		{"mixed case", "upgrade", "WebSocket", true},

--- a/internal/server/proxy_handler_test.go
+++ b/internal/server/proxy_handler_test.go
@@ -1,0 +1,224 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+func TestProxyHandlerForwardsMatchingRequests(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Backend", "reached")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("backend response"))
+	}))
+	defer backend.Close()
+
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("fallback response"))
+	})
+
+	handler, err := newProxyHandler(fallback, backend.URL, "/api/")
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %d", rec.Code)
+	}
+	if rec.Header().Get("X-Backend") != "reached" {
+		t.Error("request did not reach backend")
+	}
+	body := rec.Body.String()
+	if body != "backend response" {
+		t.Errorf("expected 'backend response', got %q", body)
+	}
+}
+
+func TestProxyHandlerFallsBackForNonMatchingPaths(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("backend"))
+	}))
+	defer backend.Close()
+
+	fallback := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("fallback"))
+	})
+
+	handler, err := newProxyHandler(fallback, backend.URL, "/api/")
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/static/file.js", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if body != "fallback" {
+		t.Errorf("expected 'fallback', got %q", body)
+	}
+}
+
+func TestProxyHandlerPreservesQueryParams(t *testing.T) {
+	var receivedQuery string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	handler, err := newProxyHandler(http.NotFoundHandler(), backend.URL, "/api/")
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test?foo=bar&baz=qux", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if receivedQuery != "foo=bar&baz=qux" {
+		t.Errorf("expected query 'foo=bar&baz=qux', got %q", receivedQuery)
+	}
+}
+
+func TestProxyHandlerForwardsRequestBody(t *testing.T) {
+	var receivedBody string
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		receivedBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	handler, err := newProxyHandler(http.NotFoundHandler(), backend.URL, "/api/")
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/test", strings.NewReader(`{"key":"value"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if receivedBody != `{"key":"value"}` {
+		t.Errorf("expected body '{\"key\":\"value\"}', got %q", receivedBody)
+	}
+}
+
+func TestProxyHandlerReturns502OnBackendError(t *testing.T) {
+	handler, err := newProxyHandler(http.NotFoundHandler(), "http://localhost:1", "/api/")
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/test", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadGateway {
+		t.Errorf("expected status 502, got %d", rec.Code)
+	}
+}
+
+func TestProxyHandlerDetectsWebSocketUpgrade(t *testing.T) {
+	handler := &proxyHandler{}
+
+	tests := []struct {
+		name           string
+		connectionHdr  string
+		upgradeHdr     string
+		expectUpgrade  bool
+	}{
+		{"websocket upgrade", "Upgrade", "websocket", true},
+		{"mixed case", "upgrade", "WebSocket", true},
+		{"keep-alive, upgrade", "keep-alive, Upgrade", "websocket", true},
+		{"no upgrade header", "keep-alive", "", false},
+		{"no connection header", "", "websocket", false},
+		{"wrong upgrade value", "Upgrade", "h2c", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+			if tc.connectionHdr != "" {
+				req.Header.Set("Connection", tc.connectionHdr)
+			}
+			if tc.upgradeHdr != "" {
+				req.Header.Set("Upgrade", tc.upgradeHdr)
+			}
+
+			result := handler.isWebSocketUpgrade(req)
+			if result != tc.expectUpgrade {
+				t.Errorf("expected %v, got %v", tc.expectUpgrade, result)
+			}
+		})
+	}
+}
+
+func TestProxyHandlerWebSocketIntegration(t *testing.T) {
+	upgrader := websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Logf("backend upgrade error: %v", err)
+			return
+		}
+		defer conn.Close()
+
+		_, msg, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		conn.WriteMessage(websocket.TextMessage, append([]byte("echo: "), msg...))
+	}))
+	defer backend.Close()
+
+	handler, err := newProxyHandler(http.NotFoundHandler(), backend.URL, "/api/")
+	if err != nil {
+		t.Fatalf("failed to create proxy handler: %v", err)
+	}
+
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(proxy.URL, "http") + "/api/ws"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to connect websocket: %v", err)
+	}
+	defer conn.Close()
+
+	err = conn.WriteMessage(websocket.TextMessage, []byte("hello"))
+	if err != nil {
+		t.Fatalf("failed to write message: %v", err)
+	}
+
+	_, msg, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("failed to read message: %v", err)
+	}
+
+	expected := "echo: hello"
+	if string(msg) != expected {
+		t.Errorf("expected %q, got %q", expected, string(msg))
+	}
+}


### PR DESCRIPTION
## Summary

- Add reverse proxy capability to ghttp with full WebSocket support
- Enables serving static files while proxying API/WebSocket requests to a backend server
- Useful for Docker deployments where frontend and backend run in separate containers

## Configuration

Environment variables:
- `GHTTP_SERVE_PROXY_BACKEND` - Backend URL (e.g., `http://backend:8001`)
- `GHTTP_SERVE_PROXY_PATH_PREFIX` - Path prefix to proxy (e.g., `/api/`)

CLI flags:
- `--proxy-backend` - Backend URL to proxy requests to
- `--proxy-path` - Path prefix to proxy

## Example Usage

```bash
# Serve static files and proxy /api/* to backend
ghttp --proxy-backend http://backend:8001 --proxy-path /api/
```

Or with Docker:
```yaml
environment:
  GHTTP_SERVE_PROXY_BACKEND: "http://backend:8001"
  GHTTP_SERVE_PROXY_PATH_PREFIX: "/api/"
```

## Implementation Details

- Proxy handler with automatic WebSocket upgrade detection
- HTTP reverse proxy using `httputil.ReverseProxy`
- WebSocket proxying via TCP connection hijacking
- Falls back to static file serving for non-matching paths

## Test plan

- [x] Unit tests for path matching and fallback behavior
- [x] Unit tests for WebSocket upgrade detection
- [x] Integration test for WebSocket echo server proxying
- [x] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)