### PR TITLE
Add repeatable proxy mappings

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -23,6 +23,11 @@ Or via flags:
 - WebSocket proxying via TCP connection hijacking
 - Falls back to static file serving for non-matching paths
 
+### 101: Repeatable proxy mappings via --proxy
+**Status:** Unresolved
+
+Add repeatable proxy mappings with explicit from/to semantics (`--proxy /api=http://backend:8081`) and support `GHTTP_SERVE_PROXIES=/api=http://...,/ws=http://...` for configuration. Keep from/to behavior explicit and allow multiple mappings.
+
 ## Improvements (200–299)
 
 ## BugFixes (300–399)

--- a/README.md
+++ b/README.md
@@ -78,13 +78,14 @@ Flags map to Viper configuration keys. Environment variables use the `GHTTP_` pr
 | `--no-md` | `GHTTP_SERVE_NO_MARKDOWN` | Disables Markdown rendering. |
 | `--browse` | `GHTTP_SERVE_BROWSE` | Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
 | `--logging-type` | `GHTTP_SERVE_LOGGING_TYPE` | CONSOLE or JSON. |
-| `--proxy-backend` | `GHTTP_SERVE_PROXY_BACKEND` | Requires `--proxy-path`. |
-| `--proxy-path` | `GHTTP_SERVE_PROXY_PATH_PREFIX` | Requires `--proxy-backend`. |
+| `--proxy` | `GHTTP_SERVE_PROXIES` | Repeatable from=to mapping (for example, `/api=http://backend:8081`); backend can be `http://` or `https://` regardless of frontend scheme; env uses comma-separated list. |
 | `--https` | `GHTTP_SERVE_HTTPS` | Enables self-signed HTTPS using the development certificate authority (SANs from `--https-host`); mutually exclusive with `--tls-cert` and `--tls-key`. |
 | `--https-host` | `GHTTP_HTTPS_HOSTS` | Repeatable flag; env uses comma-separated list; only used with `--https` and included in generated HTTPS certificates. |
 | `--https-cert-dir` | `GHTTP_HTTPS_CERTIFICATE_DIRECTORY` | Controls where generated certificates are stored. |
 | `--tls-cert` | `GHTTP_SERVE_TLS_CERTIFICATE` | Provide with `--tls-key`; cannot combine with `--https`. |
 | `--tls-key` | `GHTTP_SERVE_TLS_PRIVATE_KEY` | Provide with `--tls-cert`; cannot combine with `--https`. |
+
+Legacy single mapping: `--proxy-path` (from) + `--proxy-backend` (to) remain supported when `--proxy`/`GHTTP_SERVE_PROXIES` are unset.
 
 Positional port arguments map to `GHTTP_SERVE_PORT` for `ghttp` and `GHTTP_HTTPS_PORT` for `ghttp https serve`.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ After installation the `ghttp` binary is placed in `$GOBIN` (or `$GOPATH/bin`). 
 ### Key capabilities
 * Choose between HTTP/1.0 and HTTP/1.1 with `--protocol`/`-p`; the server tunes keep-alive behaviour automatically.
 * Provision a development certificate authority with `ghttp --https` (or `ghttp https setup` for manual control), storing it at `~/.config/ghttp/certs` and installing it into macOS, Linux, or Windows trust stores using native tooling.
-* Issue SAN-aware leaf certificates on demand whenever HTTPS is enabled, covering `localhost`, `127.0.0.1`, `::1`, and additional hosts supplied via repeated `--host` flags or Viper configuration.
+* Issue SAN-aware leaf certificates on demand whenever HTTPS is enabled, covering `localhost`, `127.0.0.1`, `::1`, and additional hosts supplied via repeated `--https-host` flags or Viper configuration.
 * Render Markdown files (`*.md`) to HTML automatically, treat `README.md` as a directory landing page, and skip the feature entirely with `--no-md` or `serve.no_markdown: true` in configuration.
 * When Firefox is installed, automatically configure its profiles to trust the generated certificates so browser warnings disappear on the next restart.
 * Suppress automatic directory listings by exporting `GHTTPD_DISABLE_DIR_INDEX=1`; the handler returns HTTP 403 for directory roots.
@@ -69,24 +69,25 @@ After installation the `ghttp` binary is placed in `$GOBIN` (or `$GOPATH/bin`). 
 ### Flags and environment variables
 Flags map to Viper configuration keys. Environment variables use the `GHTTP_` prefix with dots replaced by underscores.
 
-| Command scope | Flag | Environment variable | Notes |
-| --- | --- | --- | --- |
-| all commands | `--config` | n/a (flag-only) | Overrides the default config lookup (`~/.config/ghttp/config.yaml`). |
-| `ghttp`, `ghttp https serve` | `--bind` | `GHTTP_SERVE_BIND_ADDRESS` | Empty means all interfaces; logs display `localhost` for empty/`0.0.0.0`/`127.0.0.1`. |
-| `ghttp`, `ghttp https serve` | `--directory` | `GHTTP_SERVE_DIRECTORY` | Defaults to the working directory. |
-| `ghttp`, `ghttp https serve` | `--protocol` | `GHTTP_SERVE_PROTOCOL` | HTTP/1.0 or HTTP/1.1. |
-| `ghttp`, `ghttp https serve` | `--no-md` | `GHTTP_SERVE_NO_MARKDOWN` | Disables Markdown rendering. |
-| `ghttp`, `ghttp https serve` | `--browse` | `GHTTP_SERVE_BROWSE` | Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
-| `ghttp`, `ghttp https serve` | `--logging-type` | `GHTTP_SERVE_LOGGING_TYPE` | CONSOLE or JSON. |
-| `ghttp`, `ghttp https serve` | `--proxy-backend` | `GHTTP_SERVE_PROXY_BACKEND` | Requires `--proxy-path`. |
-| `ghttp`, `ghttp https serve` | `--proxy-path` | `GHTTP_SERVE_PROXY_PATH_PREFIX` | Requires `--proxy-backend`. |
-| `ghttp` | `--tls-cert` | `GHTTP_SERVE_TLS_CERTIFICATE` | Provide with `--tls-key`; cannot combine with `--https`. |
-| `ghttp` | `--tls-key` | `GHTTP_SERVE_TLS_PRIVATE_KEY` | Provide with `--tls-cert`; cannot combine with `--https`. |
-| `ghttp` | `--https` | `GHTTP_SERVE_HTTPS` | Mutually exclusive with `--tls-cert` and `--tls-key`. |
-| `ghttp`, `ghttp https serve` | `--host` | `GHTTP_HTTPS_HOSTS` | Repeatable flag; env uses comma-separated list. |
-| `ghttp https` | `--cert-dir` | `GHTTP_HTTPS_CERTIFICATE_DIRECTORY` | Controls where generated certificates are stored. |
+| Flag | Environment variable | Notes |
+| --- | --- | --- |
+| `--config` | n/a (flag-only) | Overrides the default config lookup (`~/.config/ghttp/config.yaml`). |
+| `--bind` | `GHTTP_SERVE_BIND_ADDRESS` | Empty means all interfaces; logs display `localhost` for empty/`0.0.0.0`/`127.0.0.1`. |
+| `--directory` | `GHTTP_SERVE_DIRECTORY` | Defaults to the working directory. |
+| `--protocol` | `GHTTP_SERVE_PROTOCOL` | HTTP/1.0 or HTTP/1.1. |
+| `--no-md` | `GHTTP_SERVE_NO_MARKDOWN` | Disables Markdown rendering. |
+| `--browse` | `GHTTP_SERVE_BROWSE` | Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
+| `--logging-type` | `GHTTP_SERVE_LOGGING_TYPE` | CONSOLE or JSON. |
+| `--proxy-backend` | `GHTTP_SERVE_PROXY_BACKEND` | Requires `--proxy-path`. |
+| `--proxy-path` | `GHTTP_SERVE_PROXY_PATH_PREFIX` | Requires `--proxy-backend`. |
+| `--https` | `GHTTP_SERVE_HTTPS` | Enables self-signed HTTPS using the development certificate authority (SANs from `--https-host`); mutually exclusive with `--tls-cert` and `--tls-key`. |
+| `--https-host` | `GHTTP_HTTPS_HOSTS` | Repeatable flag; env uses comma-separated list; only used with `--https` and included in generated HTTPS certificates. |
+| `--https-cert-dir` | `GHTTP_HTTPS_CERTIFICATE_DIRECTORY` | Controls where generated certificates are stored. |
+| `--tls-cert` | `GHTTP_SERVE_TLS_CERTIFICATE` | Provide with `--tls-key`; cannot combine with `--https`. |
+| `--tls-key` | `GHTTP_SERVE_TLS_PRIVATE_KEY` | Provide with `--tls-cert`; cannot combine with `--https`. |
 
 Positional port arguments map to `GHTTP_SERVE_PORT` for `ghttp` and `GHTTP_HTTPS_PORT` for `ghttp https serve`.
+
 
 ### Browser trust behaviour
 | Browser | Trust source | Restart needed? | Notes |

--- a/docs/docker-compose-ai-agents.md
+++ b/docs/docker-compose-ai-agents.md
@@ -74,6 +74,9 @@ The CLI uses Viper with an `env` prefix of `GHTTP` and replaces dots in configur
 - `serve.logging_type` → `GHTTP_SERVE_LOGGING_TYPE`
   - Logging format: `"CONSOLE"` (human-oriented) or `"JSON"` (machine-oriented).
   - Default: `"CONSOLE"`.
+- `serve.proxies` → `GHTTP_SERVE_PROXIES`
+  - Comma-separated list of from=to mappings (for example, `/api=http://backend:8081`).
+  - Use multiple entries to proxy multiple path prefixes.
 - `serve.tls_certificate` → `GHTTP_SERVE_TLS_CERTIFICATE`
   - Path inside the container to a PEM-encoded TLS certificate.
   - Used together with `GHTTP_SERVE_TLS_PRIVATE_KEY`.
@@ -230,4 +233,3 @@ For robust integration, AI agents should:
 - Keep volume mounts read-only (`:ro`) for static content, unless there is a documented need for write access.
 
 Following these guidelines will produce predictable and maintainable Docker Compose configurations that work correctly with the current gHTTP container image and CLI behavior.
-

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -18,7 +18,7 @@ type contextKey string
 const (
 	contextKeyApplicationResources contextKey = "application-resources"
 	contextKeyServeConfiguration   contextKey = "serve-configuration"
-	contextKeyHTTPSHosts           contextKey = "https-hosts"
+	contextKeyHTTPSHosts           contextKey = "https-host"
 	contextKeyHTTPSCertificateDir  contextKey = "https-certificate-directory"
 
 	defaultServePort       = "8000"
@@ -38,8 +38,8 @@ const (
 	flagNameHTTPS              = "https"
 	flagNameBrowse             = "browse"
 	flagNameLoggingType        = "logging-type"
-	flagNameCertificateDir     = "cert-dir"
-	flagNameHTTPSHosts         = "host"
+	flagNameCertificateDir     = "https-cert-dir"
+	flagNameHTTPSHosts         = "https-host"
 	flagNameProxyBackend       = "proxy-backend"
 	flagNameProxyPathPrefix    = "proxy-path"
 

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -40,6 +40,7 @@ const (
 	flagNameLoggingType        = "logging-type"
 	flagNameCertificateDir     = "https-cert-dir"
 	flagNameHTTPSHosts         = "https-host"
+	flagNameProxy              = "proxy"
 	flagNameProxyBackend       = "proxy-backend"
 	flagNameProxyPathPrefix    = "proxy-path"
 
@@ -56,6 +57,7 @@ const (
 	configKeyHTTPSCertificateDir     = "https.certificate_directory"
 	configKeyHTTPSHosts              = "https.hosts"
 	configKeyHTTPSPort               = "https.port"
+	configKeyServeProxies            = "serve.proxies"
 	configKeyProxyBackend            = "serve.proxy_backend"
 	configKeyProxyPathPrefix         = "serve.proxy_path_prefix"
 
@@ -128,6 +130,7 @@ func Execute(ctx context.Context, arguments []string) int {
 	configurationManager.SetDefault(configKeyHTTPSCertificateDir, filepath.Join(applicationConfigDir, certificates.DefaultCertificateDirectoryName))
 	configurationManager.SetDefault(configKeyHTTPSHosts, []string{"localhost", "127.0.0.1", "::1"})
 	configurationManager.SetDefault(configKeyHTTPSPort, defaultHTTPSServePort)
+	configurationManager.SetDefault(configKeyServeProxies, []string{})
 	configurationManager.SetDefault(configKeyProxyBackend, "")
 	configurationManager.SetDefault(configKeyProxyPathPrefix, "")
 	resources := &applicationResources{

--- a/internal/app/https_commands.go
+++ b/internal/app/https_commands.go
@@ -209,6 +209,7 @@ func executeHTTPSServe(cmd *cobra.Command, resources *applicationResources, serv
 		BrowseDirectories:       serveConfiguration.BrowseDirectories,
 		InitialFileRelativePath: serveConfiguration.InitialFileRelativePath,
 		LoggingType:             serveConfiguration.LoggingType,
+		ProxyRoutes:             serveConfiguration.ProxyRoutes,
 		TLS: &server.TLSConfiguration{
 			LoadedCertificate: &tlsCertificate,
 		},

--- a/internal/app/https_commands_test.go
+++ b/internal/app/https_commands_test.go
@@ -1,0 +1,163 @@
+package app
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"github.com/tyemirov/ghttp/pkg/logging"
+)
+
+func TestPrepareHTTPSContext(testingInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		hosts         []string
+		expectedHosts []string
+		expectError   bool
+	}{
+		{
+			name:          "sanitizes and stores hosts",
+			hosts:         []string{"localhost", " example.test ", "", "localhost", "127.0.0.1"},
+			expectedHosts: []string{"localhost", "example.test", "127.0.0.1"},
+			expectError:   false,
+		},
+		{
+			name:          "rejects empty hosts",
+			hosts:         []string{" ", ""},
+			expectedHosts: nil,
+			expectError:   true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			configurationManager := viper.New()
+			configurationManager.Set(configKeyHTTPSHosts, testCase.hosts)
+			certificateDirectory := testingInstance.TempDir()
+			configurationManager.Set(configKeyHTTPSCertificateDir, certificateDirectory)
+
+			resources := &applicationResources{
+				configurationManager: configurationManager,
+				loggingService:       logging.NewTestService(logging.TypeConsole),
+				defaultConfigDirPath: testingInstance.TempDir(),
+			}
+
+			command := &cobra.Command{}
+			command.SetContext(context.WithValue(context.Background(), contextKeyApplicationResources, resources))
+
+			err := prepareHTTPSContext(command)
+			if testCase.expectError {
+				if err == nil {
+					testingInstance.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				testingInstance.Fatalf("prepare https context: %v", err)
+			}
+
+			hostsValue := command.Context().Value(contextKeyHTTPSHosts)
+			if hostsValue == nil {
+				testingInstance.Fatalf("expected https hosts in context")
+			}
+			hosts, ok := hostsValue.([]string)
+			if !ok {
+				testingInstance.Fatalf("expected https hosts slice in context")
+			}
+			if !reflect.DeepEqual(hosts, testCase.expectedHosts) {
+				testingInstance.Fatalf("expected hosts %v, got %v", testCase.expectedHosts, hosts)
+			}
+
+			certificateDirectoryValue := command.Context().Value(contextKeyHTTPSCertificateDir)
+			if certificateDirectoryValue == nil {
+				testingInstance.Fatalf("expected https certificate directory in context")
+			}
+			certificateDirectoryPath, ok := certificateDirectoryValue.(string)
+			if !ok {
+				testingInstance.Fatalf("expected https certificate directory string in context")
+			}
+			absoluteCertificateDirectory, absoluteErr := filepath.Abs(certificateDirectory)
+			if absoluteErr != nil {
+				testingInstance.Fatalf("resolve certificate directory: %v", absoluteErr)
+			}
+			if certificateDirectoryPath != absoluteCertificateDirectory {
+				testingInstance.Fatalf("expected certificate directory %s, got %s", absoluteCertificateDirectory, certificateDirectoryPath)
+			}
+		})
+	}
+}
+
+func TestHTTPSCommandCertificateDirectoryFlagRegistration(testingInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		flagName      string
+		expectPresent bool
+	}{
+		{
+			name:          "new flag present",
+			flagName:      flagNameCertificateDir,
+			expectPresent: true,
+		},
+		{
+			name:          "old flag absent",
+			flagName:      "cert-dir",
+			expectPresent: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			configurationManager := viper.New()
+			resources := &applicationResources{
+				configurationManager: configurationManager,
+				loggingService:       logging.NewTestService(logging.TypeConsole),
+				defaultConfigDirPath: testingInstance.TempDir(),
+			}
+
+			serveFlags := pflag.NewFlagSet("serve", pflag.ContinueOnError)
+			configureServeFlags(serveFlags, resources.configurationManager)
+			httpsOptionFlags := pflag.NewFlagSet("serve-https-options", pflag.ContinueOnError)
+			configureServeHTTPSOptions(httpsOptionFlags, resources.configurationManager)
+
+			httpsCommand := newHTTPSCommand(resources, serveFlags, httpsOptionFlags)
+			lookupResult := httpsCommand.PersistentFlags().Lookup(testCase.flagName)
+			if testCase.expectPresent && lookupResult == nil {
+				testingInstance.Fatalf("expected flag %s to be registered", testCase.flagName)
+			}
+			if !testCase.expectPresent && lookupResult != nil {
+				testingInstance.Fatalf("expected flag %s to be absent", testCase.flagName)
+			}
+		})
+	}
+}
+
+func TestHTTPSCommandBindsCertificateDirectoryFlag(testingInstance *testing.T) {
+	configurationManager := viper.New()
+	resources := &applicationResources{
+		configurationManager: configurationManager,
+		loggingService:       logging.NewTestService(logging.TypeConsole),
+		defaultConfigDirPath: testingInstance.TempDir(),
+	}
+
+	serveFlags := pflag.NewFlagSet("serve", pflag.ContinueOnError)
+	configureServeFlags(serveFlags, resources.configurationManager)
+	httpsOptionFlags := pflag.NewFlagSet("serve-https-options", pflag.ContinueOnError)
+	configureServeHTTPSOptions(httpsOptionFlags, resources.configurationManager)
+
+	httpsCommand := newHTTPSCommand(resources, serveFlags, httpsOptionFlags)
+	desiredCertificateDirectory := testingInstance.TempDir()
+	parseErr := httpsCommand.ParseFlags([]string{"--" + flagNameCertificateDir, desiredCertificateDirectory})
+	if parseErr != nil {
+		testingInstance.Fatalf("parse flags: %v", parseErr)
+	}
+
+	configuredCertificateDirectory := configurationManager.GetString(configKeyHTTPSCertificateDir)
+	if configuredCertificateDirectory != desiredCertificateDirectory {
+		testingInstance.Fatalf("expected certificate directory %s, got %s", desiredCertificateDirectory, configuredCertificateDirectory)
+	}
+}

--- a/internal/app/proxy_routes.go
+++ b/internal/app/proxy_routes.go
@@ -1,0 +1,43 @@
+package app
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/viper"
+
+	"github.com/tyemirov/ghttp/internal/server"
+)
+
+var errInvalidProxyConfiguration = errors.New("proxy.configuration.invalid")
+
+func resolveProxyRoutes(configurationManager *viper.Viper) (server.ProxyRoutes, error) {
+	proxyMappings := configurationManager.GetStringSlice(configKeyServeProxies)
+	legacyBackend := strings.TrimSpace(configurationManager.GetString(configKeyProxyBackend))
+	legacyPathPrefix := strings.TrimSpace(configurationManager.GetString(configKeyProxyPathPrefix))
+
+	if len(proxyMappings) > 0 {
+		if legacyBackend != "" || legacyPathPrefix != "" {
+			return server.ProxyRoutes{}, fmt.Errorf("%w: proxy mappings cannot be combined with legacy proxy flags", errInvalidProxyConfiguration)
+		}
+		proxyRoutes, proxyErr := server.NewProxyRoutes(proxyMappings)
+		if proxyErr != nil {
+			return server.ProxyRoutes{}, fmt.Errorf("parse proxy mappings: %w", proxyErr)
+		}
+		return proxyRoutes, nil
+	}
+
+	if legacyBackend == "" && legacyPathPrefix == "" {
+		return server.ProxyRoutes{}, nil
+	}
+	if legacyBackend == "" || legacyPathPrefix == "" {
+		return server.ProxyRoutes{}, fmt.Errorf("%w: both proxy-backend and proxy-path must be set", errInvalidProxyConfiguration)
+	}
+
+	proxyRoutes, proxyErr := server.NewProxyRoutesFromLegacy(legacyPathPrefix, legacyBackend)
+	if proxyErr != nil {
+		return server.ProxyRoutes{}, fmt.Errorf("parse legacy proxy mapping: %w", proxyErr)
+	}
+	return proxyRoutes, nil
+}

--- a/internal/app/root_command.go
+++ b/internal/app/root_command.go
@@ -53,6 +53,7 @@ func configureServeFlags(flagSet *pflag.FlagSet, configurationManager *viper.Vip
 	flagSet.Bool(flagNameNoMarkdown, configurationManager.GetBool(configKeyServeNoMarkdown), "Disable Markdown rendering")
 	flagSet.Bool(flagNameBrowse, configurationManager.GetBool(configKeyServeBrowse), "Browse directories without automatic rendering")
 	flagSet.String(flagNameLoggingType, configurationManager.GetString(configKeyServeLoggingType), "Logging type (CONSOLE or JSON)")
+	flagSet.StringSlice(flagNameProxy, configurationManager.GetStringSlice(configKeyServeProxies), "Proxy mapping in the form /from=http://backend:8081 (repeatable)")
 	flagSet.String(flagNameProxyBackend, configurationManager.GetString(configKeyProxyBackend), "Backend URL to proxy requests to (e.g., http://backend:8001)")
 	flagSet.String(flagNameProxyPathPrefix, configurationManager.GetString(configKeyProxyPathPrefix), "Path prefix to proxy (e.g., /api/)")
 	_ = configurationManager.BindPFlag(configKeyServeBindAddress, flagSet.Lookup(flagNameBindAddress))
@@ -61,6 +62,7 @@ func configureServeFlags(flagSet *pflag.FlagSet, configurationManager *viper.Vip
 	_ = configurationManager.BindPFlag(configKeyServeNoMarkdown, flagSet.Lookup(flagNameNoMarkdown))
 	_ = configurationManager.BindPFlag(configKeyServeBrowse, flagSet.Lookup(flagNameBrowse))
 	_ = configurationManager.BindPFlag(configKeyServeLoggingType, flagSet.Lookup(flagNameLoggingType))
+	_ = configurationManager.BindPFlag(configKeyServeProxies, flagSet.Lookup(flagNameProxy))
 	_ = configurationManager.BindPFlag(configKeyProxyBackend, flagSet.Lookup(flagNameProxyBackend))
 	_ = configurationManager.BindPFlag(configKeyProxyPathPrefix, flagSet.Lookup(flagNameProxyPathPrefix))
 }

--- a/internal/app/root_command.go
+++ b/internal/app/root_command.go
@@ -67,7 +67,7 @@ func configureServeFlags(flagSet *pflag.FlagSet, configurationManager *viper.Vip
 
 func configureServeHTTPSOptions(flagSet *pflag.FlagSet, configurationManager *viper.Viper) {
 	flagSet.Bool(flagNameHTTPS, configurationManager.GetBool(configKeyServeHTTPS), "Serve over HTTPS using a self-signed certificate")
-	flagSet.StringSlice(flagNameHTTPSHosts, configurationManager.GetStringSlice(configKeyHTTPSHosts), "Hostnames or IP addresses for automatic HTTPS certificates")
+	flagSet.StringSlice(flagNameHTTPSHosts, configurationManager.GetStringSlice(configKeyHTTPSHosts), "Hostnames or IP addresses included in generated HTTPS certificates (only used with --https)")
 	_ = configurationManager.BindPFlag(configKeyServeHTTPS, flagSet.Lookup(flagNameHTTPS))
 	_ = configurationManager.BindPFlag(configKeyHTTPSHosts, flagSet.Lookup(flagNameHTTPSHosts))
 }

--- a/internal/app/root_command_test.go
+++ b/internal/app/root_command_test.go
@@ -26,7 +26,7 @@ func TestNewRootCommandProvidesHTTPSFlagOnce(t *testing.T) {
 
 	rootCommand := newRootCommand(resources)
 	if rootCommand.Flags().Lookup(flagNameHTTPSHosts) == nil {
-		t.Fatalf("expected host flag to be registered")
+		t.Fatalf("expected https-host flag to be registered")
 	}
 
 	httpsResources := &applicationResources{

--- a/internal/app/root_command_test.go
+++ b/internal/app/root_command_test.go
@@ -45,6 +45,20 @@ func TestNewRootCommandProvidesHTTPSFlagOnce(t *testing.T) {
 	}
 }
 
+func TestNewRootCommandProvidesProxyFlag(testingInstance *testing.T) {
+	configurationManager := viper.New()
+	resources := &applicationResources{
+		configurationManager: configurationManager,
+		loggingService:       logging.NewTestService(logging.TypeConsole),
+		defaultConfigDirPath: testingInstance.TempDir(),
+	}
+
+	rootCommand := newRootCommand(resources)
+	if rootCommand.Flags().Lookup(flagNameProxy) == nil {
+		testingInstance.Fatalf("expected proxy flag to be registered")
+	}
+}
+
 func TestRootCommandBindsBrowseFlag(t *testing.T) {
 	configurationManager := viper.New()
 	resources := &applicationResources{

--- a/internal/app/serve_command.go
+++ b/internal/app/serve_command.go
@@ -44,8 +44,7 @@ type ServeConfiguration struct {
 	BrowseDirectories       bool
 	InitialFileRelativePath string
 	LoggingType             string
-	ProxyBackendURL         string
-	ProxyPathPrefix         string
+	ProxyRoutes             server.ProxyRoutes
 }
 
 func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey string, allowTLSFiles bool) error {
@@ -143,8 +142,10 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 		disableDirectoryListing = false
 	}
 
-	proxyBackendURL := strings.TrimSpace(configurationManager.GetString(configKeyProxyBackend))
-	proxyPathPrefix := strings.TrimSpace(configurationManager.GetString(configKeyProxyPathPrefix))
+	proxyRoutes, proxyErr := resolveProxyRoutes(configurationManager)
+	if proxyErr != nil {
+		return proxyErr
+	}
 
 	serveConfiguration := ServeConfiguration{
 		BindAddress:             bindAddress,
@@ -159,8 +160,7 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 		BrowseDirectories:       browseDirectories,
 		InitialFileRelativePath: initialFileRelativePath,
 		LoggingType:             loggingTypeValue,
-		ProxyBackendURL:         proxyBackendURL,
-		ProxyPathPrefix:         proxyPathPrefix,
+		ProxyRoutes:             proxyRoutes,
 	}
 
 	if loggerErr := resources.updateLogger(loggingTypeValue); loggerErr != nil {
@@ -198,8 +198,7 @@ func runServe(cmd *cobra.Command) error {
 		BrowseDirectories:       serveConfiguration.BrowseDirectories,
 		InitialFileRelativePath: serveConfiguration.InitialFileRelativePath,
 		LoggingType:             serveConfiguration.LoggingType,
-		ProxyBackendURL:         serveConfiguration.ProxyBackendURL,
-		ProxyPathPrefix:         serveConfiguration.ProxyPathPrefix,
+		ProxyRoutes:             serveConfiguration.ProxyRoutes,
 	}
 	if serveConfiguration.TLSCertificatePath != "" {
 		fileServerConfiguration.TLS = &server.TLSConfiguration{

--- a/internal/server/file_server.go
+++ b/internal/server/file_server.go
@@ -58,8 +58,7 @@ type FileServerConfiguration struct {
 	InitialFileRelativePath string
 	LoggingType             string
 	TLS                     *TLSConfiguration
-	ProxyBackendURL         string
-	ProxyPathPrefix         string
+	ProxyRoutes             ProxyRoutes
 }
 
 // TLSConfiguration describes transport layer security configuration.
@@ -189,13 +188,8 @@ func (fileServer FileServer) buildFileHandler(configuration FileServerConfigurat
 	if configuration.InitialFileRelativePath != "" && !configuration.BrowseDirectories {
 		handler = newInitialFileHandler(handler, configuration.InitialFileRelativePath)
 	}
-	if configuration.ProxyBackendURL != "" && configuration.ProxyPathPrefix != "" {
-		proxyHandler, err := newProxyHandler(handler, configuration.ProxyBackendURL, configuration.ProxyPathPrefix)
-		if err != nil {
-			fileServer.loggingService.Error("failed to create proxy handler", err)
-		} else {
-			handler = proxyHandler
-		}
+	if !configuration.ProxyRoutes.IsEmpty() {
+		handler = newProxyHandler(handler, configuration.ProxyRoutes)
 	}
 	return handler
 }

--- a/internal/server/proxy_handler_test.go
+++ b/internal/server/proxy_handler_test.go
@@ -1,0 +1,373 @@
+package server
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHostWithoutPort(testingInstance *testing.T) {
+	testCases := []struct {
+		name     string
+		hostPort string
+		expected string
+	}{
+		{
+			name:     "hostname with port",
+			hostPort: "example.com:443",
+			expected: "example.com",
+		},
+		{
+			name:     "ipv4 with port",
+			hostPort: "127.0.0.1:8080",
+			expected: "127.0.0.1",
+		},
+		{
+			name:     "ipv6 with port",
+			hostPort: "[::1]:8443",
+			expected: "::1",
+		},
+		{
+			name:     "hostname without port",
+			hostPort: "example.com",
+			expected: "example.com",
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			result := hostWithoutPort(testCase.hostPort)
+			if result != testCase.expected {
+				testingInstance.Fatalf("expected %s, got %s", testCase.expected, result)
+			}
+		})
+	}
+}
+
+func TestProxyHandlerWebSocketRequiresHijacker(testingInstance *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	proxyRoutes, routeErr := NewProxyRoutes([]string{"/api=" + backend.URL})
+	if routeErr != nil {
+		testingInstance.Fatalf("proxy routes: %v", routeErr)
+	}
+
+	baseHandler := http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+		responseWriter.WriteHeader(http.StatusOK)
+	})
+
+	handler := newProxyHandler(baseHandler, proxyRoutes)
+	request := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	request.Header.Set(headerConnection, "Upgrade")
+	request.Header.Set(headerUpgrade, valueWebSocket)
+	responseRecorder := httptest.NewRecorder()
+
+	handler.ServeHTTP(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusInternalServerError {
+		testingInstance.Fatalf("expected status %d, got %d", http.StatusInternalServerError, responseRecorder.Code)
+	}
+}
+
+func TestProxyRouteHandlerReadResponseFailure(testingInstance *testing.T) {
+	listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	if listenErr != nil {
+		testingInstance.Fatalf("listen: %v", listenErr)
+	}
+	defer listener.Close()
+
+	handledConnection := make(chan struct{}, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer connection.Close()
+		_ = connection.SetReadDeadline(time.Now().Add(2 * time.Second))
+		readBuffer := make([]byte, 64)
+		_, _ = connection.Read(readBuffer)
+		_, _ = connection.Write([]byte("not-http\r\n\r\n"))
+		handledConnection <- struct{}{}
+	}()
+
+	backendURL := "http://" + listener.Addr().String()
+	route, routeErr := newProxyRoute("/api", backendURL)
+	if routeErr != nil {
+		testingInstance.Fatalf("route: %v", routeErr)
+	}
+	routeHandler := newProxyRouteHandler(route)
+
+	clientConnection, clientPeer := net.Pipe()
+	defer clientConnection.Close()
+	defer clientPeer.Close()
+	clientBuffer := bufio.NewReadWriter(bufio.NewReader(strings.NewReader("")), bufio.NewWriter(io.Discard))
+	responseWriter := newHijackableResponseWriter(clientConnection, clientBuffer)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	request.Header.Set(headerConnection, "Upgrade")
+	request.Header.Set(headerUpgrade, valueWebSocket)
+
+	routeHandler.handleWebSocket(responseWriter, request)
+
+	select {
+	case <-handledConnection:
+	case <-time.After(2 * time.Second):
+		testingInstance.Fatalf("backend did not handle connection")
+	}
+}
+
+func TestProxyRouteHandlerResponseWriteFailure(testingInstance *testing.T) {
+	listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	if listenErr != nil {
+		testingInstance.Fatalf("listen: %v", listenErr)
+	}
+	defer listener.Close()
+
+	handledConnection := make(chan struct{}, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer connection.Close()
+		backendReader := bufio.NewReader(connection)
+		for {
+			line, readErr := backendReader.ReadString('\n')
+			if readErr != nil {
+				break
+			}
+			if line == "\r\n" {
+				break
+			}
+		}
+		_, _ = connection.Write([]byte("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n"))
+		handledConnection <- struct{}{}
+	}()
+
+	backendURL := "http://" + listener.Addr().String()
+	route, routeErr := newProxyRoute("/api", backendURL)
+	if routeErr != nil {
+		testingInstance.Fatalf("route: %v", routeErr)
+	}
+	routeHandler := newProxyRouteHandler(route)
+
+	clientConnection, clientPeer := net.Pipe()
+	defer clientConnection.Close()
+	defer clientPeer.Close()
+	writeErrorConnection := &writeErrorConn{
+		Conn:       clientConnection,
+		writeError: errors.New("write failure"),
+	}
+	clientBuffer := bufio.NewReadWriter(bufio.NewReader(clientPeer), bufio.NewWriter(clientPeer))
+	responseWriter := newHijackableResponseWriter(writeErrorConnection, clientBuffer)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	request.Header.Set(headerConnection, "Upgrade")
+	request.Header.Set(headerUpgrade, valueWebSocket)
+
+	routeHandler.handleWebSocket(responseWriter, request)
+
+	if !writeErrorConnection.writeCalled {
+		testingInstance.Fatalf("expected client write to be attempted")
+	}
+
+	select {
+	case <-handledConnection:
+	case <-time.After(2 * time.Second):
+		testingInstance.Fatalf("backend did not handle connection")
+	}
+}
+
+func TestProxyRouteHandlerUpgradeWriteFailure(testingInstance *testing.T) {
+	listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	if listenErr != nil {
+		testingInstance.Fatalf("listen: %v", listenErr)
+	}
+	defer listener.Close()
+
+	handledConnection := make(chan struct{}, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		if tcpConnection, ok := connection.(*net.TCPConn); ok {
+			_ = tcpConnection.SetLinger(0)
+		}
+		_ = connection.Close()
+		handledConnection <- struct{}{}
+	}()
+
+	backendURL := "http://" + listener.Addr().String()
+	route, routeErr := newProxyRoute("/api", backendURL)
+	if routeErr != nil {
+		testingInstance.Fatalf("route: %v", routeErr)
+	}
+	routeHandler := newProxyRouteHandler(route)
+
+	clientConnection, clientPeer := net.Pipe()
+	defer clientConnection.Close()
+	defer clientPeer.Close()
+	clientBuffer := bufio.NewReadWriter(bufio.NewReader(strings.NewReader("")), bufio.NewWriter(io.Discard))
+	responseWriter := newHijackableResponseWriter(clientConnection, clientBuffer)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	request.Header.Set(headerConnection, "Upgrade")
+	request.Header.Set(headerUpgrade, valueWebSocket)
+
+	routeHandler.handleWebSocket(responseWriter, request)
+
+	select {
+	case <-handledConnection:
+	case <-time.After(2 * time.Second):
+		testingInstance.Fatalf("backend did not handle connection")
+	}
+}
+
+func TestProxyRouteHandlerTLSHandshakeFailure(testingInstance *testing.T) {
+	listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	if listenErr != nil {
+		testingInstance.Fatalf("listen: %v", listenErr)
+	}
+	defer listener.Close()
+
+	handledConnection := make(chan struct{}, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		_ = connection.Close()
+		handledConnection <- struct{}{}
+	}()
+
+	backendURL := &url.URL{
+		Scheme: "https",
+		Host:   listener.Addr().String(),
+	}
+	route, routeErr := newProxyRoute("/api", backendURL.String())
+	if routeErr != nil {
+		testingInstance.Fatalf("route: %v", routeErr)
+	}
+	routeHandler := newProxyRouteHandler(route)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	request.Header.Set(headerConnection, "Upgrade")
+	request.Header.Set(headerUpgrade, valueWebSocket)
+	responseRecorder := httptest.NewRecorder()
+
+	routeHandler.handleWebSocket(responseRecorder, request)
+
+	if responseRecorder.Code != http.StatusBadGateway {
+		testingInstance.Fatalf("expected status %d, got %d", http.StatusBadGateway, responseRecorder.Code)
+	}
+
+	select {
+	case <-handledConnection:
+	case <-time.After(2 * time.Second):
+		testingInstance.Fatalf("backend did not handle connection")
+	}
+}
+
+func TestProxyRouteHandlerHijackFailure(testingInstance *testing.T) {
+	listener, listenErr := net.Listen("tcp", "127.0.0.1:0")
+	if listenErr != nil {
+		testingInstance.Fatalf("listen: %v", listenErr)
+	}
+	defer listener.Close()
+
+	handledConnection := make(chan struct{}, 1)
+	go func() {
+		connection, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		_ = connection.Close()
+		handledConnection <- struct{}{}
+	}()
+
+	backendURL := "http://" + listener.Addr().String()
+	route, routeErr := newProxyRoute("/api", backendURL)
+	if routeErr != nil {
+		testingInstance.Fatalf("route: %v", routeErr)
+	}
+	routeHandler := newProxyRouteHandler(route)
+
+	request := httptest.NewRequest(http.MethodGet, "/api/ws", nil)
+	request.Header.Set(headerConnection, "Upgrade")
+	request.Header.Set(headerUpgrade, valueWebSocket)
+
+	failingWriter := newHijackableResponseWriter(nil, nil)
+	failingWriter.hijackFailure = errors.New("hijack failed")
+
+	routeHandler.handleWebSocket(failingWriter, request)
+
+	if failingWriter.statusCode != http.StatusInternalServerError {
+		testingInstance.Fatalf("expected status %d, got %d", http.StatusInternalServerError, failingWriter.statusCode)
+	}
+
+	select {
+	case <-handledConnection:
+	case <-time.After(2 * time.Second):
+		testingInstance.Fatalf("backend did not handle connection")
+	}
+}
+
+type hijackableResponseWriter struct {
+	header        http.Header
+	statusCode    int
+	wroteHeader   bool
+	hijackConn    net.Conn
+	hijackBuffer  *bufio.ReadWriter
+	hijackFailure error
+}
+
+func newHijackableResponseWriter(connection net.Conn, readWriter *bufio.ReadWriter) *hijackableResponseWriter {
+	return &hijackableResponseWriter{
+		header:       make(http.Header),
+		statusCode:   http.StatusOK,
+		hijackConn:   connection,
+		hijackBuffer: readWriter,
+	}
+}
+
+func (writer *hijackableResponseWriter) Header() http.Header {
+	return writer.header
+}
+
+func (writer *hijackableResponseWriter) Write(data []byte) (int, error) {
+	if !writer.wroteHeader {
+		writer.WriteHeader(http.StatusOK)
+	}
+	return len(data), nil
+}
+
+func (writer *hijackableResponseWriter) WriteHeader(statusCode int) {
+	writer.statusCode = statusCode
+	writer.wroteHeader = true
+}
+
+func (writer *hijackableResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	return writer.hijackConn, writer.hijackBuffer, writer.hijackFailure
+}
+
+type writeErrorConn struct {
+	net.Conn
+	writeError  error
+	writeCalled bool
+}
+
+func (connection *writeErrorConn) Write(data []byte) (int, error) {
+	connection.writeCalled = true
+	return 0, connection.writeError
+}

--- a/internal/server/proxy_routes.go
+++ b/internal/server/proxy_routes.go
@@ -1,0 +1,126 @@
+package server
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+const (
+	proxyMappingSeparator = "="
+	proxyPathPrefixStart  = "/"
+	proxySchemeHTTP       = "http"
+	proxySchemeHTTPS      = "https"
+)
+
+var (
+	ErrInvalidProxyRoute  = errors.New("proxy.route.invalid")
+	ErrInvalidProxyRoutes = errors.New("proxy.routes.invalid")
+)
+
+type ProxyRoutes struct {
+	routes []proxyRoute
+}
+
+type proxyRoute struct {
+	pathPrefix string
+	backendURL *url.URL
+}
+
+func NewProxyRoutes(routeMappings []string) (ProxyRoutes, error) {
+	if len(routeMappings) == 0 {
+		return ProxyRoutes{}, nil
+	}
+	seenPrefixes := map[string]struct{}{}
+	parsedRoutes := make([]proxyRoute, 0, len(routeMappings))
+	for _, mapping := range routeMappings {
+		route, parseErr := parseProxyMapping(mapping)
+		if parseErr != nil {
+			return ProxyRoutes{}, parseErr
+		}
+		if _, exists := seenPrefixes[route.pathPrefix]; exists {
+			return ProxyRoutes{}, fmt.Errorf("%w: duplicate path prefix %s", ErrInvalidProxyRoutes, route.pathPrefix)
+		}
+		seenPrefixes[route.pathPrefix] = struct{}{}
+		parsedRoutes = append(parsedRoutes, route)
+	}
+	sort.SliceStable(parsedRoutes, func(leftIndex int, rightIndex int) bool {
+		return len(parsedRoutes[leftIndex].pathPrefix) > len(parsedRoutes[rightIndex].pathPrefix)
+	})
+	return ProxyRoutes{routes: parsedRoutes}, nil
+}
+
+func NewProxyRoutesFromLegacy(pathPrefix string, backendURL string) (ProxyRoutes, error) {
+	trimmedPathPrefix := strings.TrimSpace(pathPrefix)
+	trimmedBackendURL := strings.TrimSpace(backendURL)
+	if trimmedPathPrefix == "" && trimmedBackendURL == "" {
+		return ProxyRoutes{}, nil
+	}
+	route, routeErr := newProxyRoute(trimmedPathPrefix, trimmedBackendURL)
+	if routeErr != nil {
+		return ProxyRoutes{}, routeErr
+	}
+	return ProxyRoutes{routes: []proxyRoute{route}}, nil
+}
+
+func (routes ProxyRoutes) IsEmpty() bool {
+	return len(routes.routes) == 0
+}
+
+func (routes ProxyRoutes) Count() int {
+	return len(routes.routes)
+}
+
+func parseProxyMapping(mapping string) (proxyRoute, error) {
+	trimmedMapping := strings.TrimSpace(mapping)
+	if trimmedMapping == "" {
+		return proxyRoute{}, fmt.Errorf("%w: empty mapping", ErrInvalidProxyRoute)
+	}
+	parts := strings.SplitN(trimmedMapping, proxyMappingSeparator, 2)
+	if len(parts) != 2 {
+		return proxyRoute{}, fmt.Errorf("%w: mapping must be in /from=http://backend form", ErrInvalidProxyRoute)
+	}
+	pathPrefix := strings.TrimSpace(parts[0])
+	backendURL := strings.TrimSpace(parts[1])
+	return newProxyRoute(pathPrefix, backendURL)
+}
+
+func newProxyRoute(pathPrefix string, backendURL string) (proxyRoute, error) {
+	if pathPrefix == "" {
+		return proxyRoute{}, fmt.Errorf("%w: empty path prefix", ErrInvalidProxyRoute)
+	}
+	if !strings.HasPrefix(pathPrefix, proxyPathPrefixStart) {
+		return proxyRoute{}, fmt.Errorf("%w: path prefix must start with /", ErrInvalidProxyRoute)
+	}
+	parsedURL, parseErr := parseProxyBackendURL(backendURL)
+	if parseErr != nil {
+		return proxyRoute{}, parseErr
+	}
+	return proxyRoute{
+		pathPrefix: pathPrefix,
+		backendURL: parsedURL,
+	}, nil
+}
+
+func parseProxyBackendURL(backendURL string) (*url.URL, error) {
+	if strings.TrimSpace(backendURL) == "" {
+		return nil, fmt.Errorf("%w: empty backend url", ErrInvalidProxyRoute)
+	}
+	parsedURL, parseErr := url.Parse(backendURL)
+	if parseErr != nil {
+		return nil, fmt.Errorf("%w: parse backend url: %s", ErrInvalidProxyRoute, parseErr.Error())
+	}
+	if !strings.EqualFold(parsedURL.Scheme, proxySchemeHTTP) && !strings.EqualFold(parsedURL.Scheme, proxySchemeHTTPS) {
+		return nil, fmt.Errorf("%w: backend url must use http or https", ErrInvalidProxyRoute)
+	}
+	if parsedURL.Host == "" {
+		return nil, fmt.Errorf("%w: backend url must include host", ErrInvalidProxyRoute)
+	}
+	hostname := parsedURL.Hostname()
+	if hostname == "" || strings.HasSuffix(parsedURL.Host, ":") || strings.Contains(hostname, "//") {
+		return nil, fmt.Errorf("%w: backend url must include valid host", ErrInvalidProxyRoute)
+	}
+	return parsedURL, nil
+}

--- a/internal/server/proxy_routes_test.go
+++ b/internal/server/proxy_routes_test.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestNewProxyRoutes(testingInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		mappings      []string
+		expectedCount int
+		expectError   bool
+		expectedErr   error
+	}{
+		{
+			name:          "empty list",
+			mappings:      nil,
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name:          "valid mappings",
+			mappings:      []string{"/api=http://backend:8081", "/ws=https://backend:8443"},
+			expectedCount: 2,
+			expectError:   false,
+		},
+		{
+			name:          "missing separator",
+			mappings:      []string{"/apihttp://backend:8081"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "empty path prefix",
+			mappings:      []string{"=http://backend:8081"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "path prefix without slash",
+			mappings:      []string{"api=http://backend:8081"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "empty backend",
+			mappings:      []string{"/api="},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "invalid scheme",
+			mappings:      []string{"/api=ftp://backend"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "missing host",
+			mappings:      []string{"/api=http://"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "host with trailing colon",
+			mappings:      []string{"/api=http://backend:"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "parse error",
+			mappings:      []string{"/api=http://[::1"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoute,
+		},
+		{
+			name:          "duplicate prefix",
+			mappings:      []string{"/api=http://backend:8081", "/api=http://backend:8082"},
+			expectedCount: 0,
+			expectError:   true,
+			expectedErr:   ErrInvalidProxyRoutes,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			proxyRoutes, err := NewProxyRoutes(testCase.mappings)
+			if testCase.expectError {
+				if err == nil {
+					testingInstance.Fatalf("expected error")
+				}
+				if testCase.expectedErr != nil && !errors.Is(err, testCase.expectedErr) {
+					testingInstance.Fatalf("expected error %s, got %v", testCase.expectedErr.Error(), err)
+				}
+				return
+			}
+			if err != nil {
+				testingInstance.Fatalf("unexpected error: %v", err)
+			}
+			if proxyRoutes.Count() != testCase.expectedCount {
+				testingInstance.Fatalf("expected %d routes, got %d", testCase.expectedCount, proxyRoutes.Count())
+			}
+		})
+	}
+}
+
+func TestNewProxyRoutesFromLegacy(testingInstance *testing.T) {
+	testCases := []struct {
+		name          string
+		pathPrefix    string
+		backendURL    string
+		expectedCount int
+		expectError   bool
+	}{
+		{
+			name:          "empty legacy config",
+			pathPrefix:    "",
+			backendURL:    "",
+			expectedCount: 0,
+			expectError:   false,
+		},
+		{
+			name:          "valid legacy config",
+			pathPrefix:    "/api",
+			backendURL:    "http://backend:8081",
+			expectedCount: 1,
+			expectError:   false,
+		},
+		{
+			name:        "missing backend",
+			pathPrefix:  "/api",
+			backendURL:  "",
+			expectError: true,
+		},
+		{
+			name:        "missing path prefix",
+			pathPrefix:  "",
+			backendURL:  "http://backend:8081",
+			expectError: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		testingInstance.Run(testCase.name, func(testingInstance *testing.T) {
+			proxyRoutes, err := NewProxyRoutesFromLegacy(testCase.pathPrefix, testCase.backendURL)
+			if testCase.expectError {
+				if err == nil {
+					testingInstance.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				testingInstance.Fatalf("unexpected error: %v", err)
+			}
+			if proxyRoutes.Count() != testCase.expectedCount {
+				testingInstance.Fatalf("expected %d routes, got %d", testCase.expectedCount, proxyRoutes.Count())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add repeatable proxy mappings via --proxy and GHTTP_SERVE_PROXIES
- introduce validated proxy routes with longest-prefix match and legacy fallback
- expand proxy tests (routes, routing, websocket error branches)

## Testing
- go test ./...
- go vet ./...
- staticcheck ./...
- ineffassign ./...