### PR TITLE
Align default port docs and docker metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,6 @@ LABEL org.temirov.ghttp.runtime-image=gcr.io/distroless/base-debian12
 WORKDIR /app
 COPY --from=builder /out/ghttp /app/ghttp
 USER 65532:65532
-EXPOSE 8080
+EXPOSE 8000
 ENTRYPOINT ["/app/ghttp"]
     

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -39,4 +39,9 @@ Add a `GHTTP_CONFIG_FILE` environment variable counterpart to the `--config` fla
 
 ## Maintenance (400–499)
 
+### 401: Remove manual HTTPS CLI workflow
+**Status:** Resolved
+
+Drop the `ghttp https` CLI subcommands so `--https` is the single self-managed certificate path. Keep internal HTTPS plumbing for automated flow.
+
 ## Planning

--- a/README.md
+++ b/README.md
@@ -51,15 +51,13 @@ After installation the `ghttp` binary is placed in `$GOBIN` (or `$GOPATH/bin`). 
 | Serve a specific directory on a chosen port | `ghttp --directory /srv/www 9000` | Exposes `/srv/www` at <http://localhost:9000>. |
 | Bind to a specific interface | `ghttp --bind 192.168.1.5 8080` | Restricts listening to the provided IP address. |
 | Serve HTTPS with an existing certificate | `ghttp --tls-cert cert.pem --tls-key key.pem 8443` | Keeps backwards-compatible manual TLS support. |
-| Provision and trust the development root CA | `ghttp https setup` | Generates `~/.config/ghttp/certs/ca.pem` and installs it into the OS trust store (may require elevated privileges). |
 | Serve HTTPS with self-signed certificates | `ghttp --https 8443` | Installs the development CA, serves HTTPS, and removes credentials on exit. |
 | Disable Markdown rendering | `ghttp --no-md` | Serves raw Markdown assets without HTML conversion. |
 | Switch logging format | `ghttp --logging-type JSON` | Emits structured JSON logs instead of the default console view. |
-| Remove the development certificates | `ghttp https uninstall` | Deletes local key material and removes the CA from the OS trust store. |
 
 ### Key capabilities
 * Choose between HTTP/1.0 and HTTP/1.1 with `--protocol`/`-p`; the server tunes keep-alive behaviour automatically.
-* Provision a development certificate authority with `ghttp --https` (or `ghttp https setup` for manual control), storing it at `~/.config/ghttp/certs` and installing it into macOS, Linux, or Windows trust stores using native tooling.
+* Provision a development certificate authority with `ghttp --https`, storing it at `~/.config/ghttp/certs` and installing it into macOS, Linux, or Windows trust stores using native tooling.
 * Issue SAN-aware leaf certificates on demand whenever HTTPS is enabled, covering `localhost`, `127.0.0.1`, `::1`, and additional hosts supplied via repeated `--https-host` flags or Viper configuration.
 * Render Markdown files (`*.md`) to HTML automatically, treat `README.md` as a directory landing page, and skip the feature entirely with `--no-md` or `serve.no_markdown: true` in configuration.
 * When Firefox is installed, automatically configure its profiles to trust the generated certificates so browser warnings disappear on the next restart.
@@ -81,13 +79,12 @@ Flags map to Viper configuration keys. Environment variables use the `GHTTP_` pr
 | `--proxy` | `GHTTP_SERVE_PROXIES` | Repeatable from=to mapping (for example, `/api=http://backend:8081`); backend can be `http://` or `https://` regardless of frontend scheme; env uses comma-separated list. |
 | `--https` | `GHTTP_SERVE_HTTPS` | Enables self-signed HTTPS using the development certificate authority (SANs from `--https-host`); mutually exclusive with `--tls-cert` and `--tls-key`. |
 | `--https-host` | `GHTTP_HTTPS_HOSTS` | Repeatable flag; env uses comma-separated list; only used with `--https` and included in generated HTTPS certificates. |
-| `--https-cert-dir` | `GHTTP_HTTPS_CERTIFICATE_DIRECTORY` | Controls where generated certificates are stored. |
 | `--tls-cert` | `GHTTP_SERVE_TLS_CERTIFICATE` | Provide with `--tls-key`; cannot combine with `--https`. |
 | `--tls-key` | `GHTTP_SERVE_TLS_PRIVATE_KEY` | Provide with `--tls-cert`; cannot combine with `--https`. |
 
 Legacy single mapping: `--proxy-path` (from) + `--proxy-backend` (to) remain supported when `--proxy`/`GHTTP_SERVE_PROXIES` are unset.
 
-Positional port arguments map to `GHTTP_SERVE_PORT` for `ghttp` and `GHTTP_HTTPS_PORT` for `ghttp https serve`.
+Positional port arguments map to `GHTTP_SERVE_PORT` for `ghttp`.
 
 
 ### Browser trust behaviour

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pull and run the latest Docker image:
 
 ```bash
 docker pull ghcr.io/tyemirov/ghttp:latest
-docker run -p 8080:8080 -v $(pwd):/data ghcr.io/tyemirov/ghttp:latest --directory /data
+docker run -p 8000:8000 -v $(pwd):/data ghcr.io/tyemirov/ghttp:latest --directory /data
 ```
 
 Custom port and directory examples:
@@ -49,7 +49,7 @@ After installation the `ghttp` binary is placed in `$GOBIN` (or `$GOPATH/bin`). 
 | --- | --- | --- |
 | Serve the current working directory on the default HTTP port 8000 | `ghttp` | Mirrors `python -m http.server` with structured logging. |
 | Serve a specific directory on a chosen port | `ghttp --directory /srv/www 9000` | Exposes `/srv/www` at <http://localhost:9000>. |
-| Bind to a specific interface | `ghttp --bind 192.168.1.5 8080` | Restricts listening to the provided IP address. |
+| Bind to a specific interface | `ghttp --bind 192.168.1.5 8000` | Restricts listening to the provided IP address. |
 | Serve HTTPS with an existing certificate | `ghttp --tls-cert cert.pem --tls-key key.pem 8443` | Keeps backwards-compatible manual TLS support. |
 | Serve HTTPS with self-signed certificates | `ghttp --https` | Defaults to port 8443, installs the development CA, serves HTTPS, and removes credentials on exit. |
 | Disable Markdown rendering | `ghttp --no-md` | Serves raw Markdown assets without HTML conversion. |
@@ -78,6 +78,8 @@ Flags map to Viper configuration keys. Environment variables use the `GHTTP_` pr
 | `--browse` | `GHTTP_SERVE_BROWSE` | Folder URLs always return a directory listing, even if index.html or README.md exists; direct file requests (including .md) still render normally. Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
 | `--logging-type` | `GHTTP_SERVE_LOGGING_TYPE` | CONSOLE or JSON. |
 | `--proxy` | `GHTTP_SERVE_PROXIES` | Enables reverse proxy. Repeatable from=to mapping (for example, `/api=http://backend:8081`); backend can be `http://` or `https://` regardless of frontend scheme; env uses comma-separated list. |
+| `--proxy-path` | `GHTTP_SERVE_PROXY_PATH_PREFIX` | Legacy from-path prefix (for example, `/api`); requires `--proxy-backend`. |
+| `--proxy-backend` | `GHTTP_SERVE_PROXY_BACKEND` | Legacy to-backend URL (for example, `http://backend:8081`); requires `--proxy-path`. |
 | `--https` | `GHTTP_SERVE_HTTPS` | Enables self-signed HTTPS using the development certificate authority (SANs from `--https-host`); mutually exclusive with `--tls-cert` and `--tls-key`. |
 | `--https-host` | `GHTTP_HTTPS_HOSTS` | Repeatable flag; env uses comma-separated list; only used with `--https` and included in generated HTTPS certificates. |
 | `--tls-cert` | `GHTTP_SERVE_TLS_CERTIFICATE` | Provide with `--tls-key`; cannot combine with `--https`. |

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ After installation the `ghttp` binary is placed in `$GOBIN` (or `$GOPATH/bin`). 
 
 | Scenario | Example command | Notes |
 | --- | --- | --- |
-| Serve the current working directory on the default port 8000 | `ghttp` | Mirrors `python -m http.server` with structured logging. |
+| Serve the current working directory on the default HTTP port 8000 | `ghttp` | Mirrors `python -m http.server` with structured logging. |
 | Serve a specific directory on a chosen port | `ghttp --directory /srv/www 9000` | Exposes `/srv/www` at <http://localhost:9000>. |
 | Bind to a specific interface | `ghttp --bind 192.168.1.5 8080` | Restricts listening to the provided IP address. |
 | Serve HTTPS with an existing certificate | `ghttp --tls-cert cert.pem --tls-key key.pem 8443` | Keeps backwards-compatible manual TLS support. |
-| Serve HTTPS with self-signed certificates | `ghttp --https 8443` | Installs the development CA, serves HTTPS, and removes credentials on exit. |
+| Serve HTTPS with self-signed certificates | `ghttp --https` | Defaults to port 8443, installs the development CA, serves HTTPS, and removes credentials on exit. |
 | Disable Markdown rendering | `ghttp --no-md` | Serves raw Markdown assets without HTML conversion. |
 | Switch logging format | `ghttp --logging-type JSON` | Emits structured JSON logs instead of the default console view. |
 
@@ -69,14 +69,15 @@ Flags map to Viper configuration keys. Environment variables use the `GHTTP_` pr
 
 | Flag | Environment variable | Notes |
 | --- | --- | --- |
+| `PORT` (positional) | `GHTTP_SERVE_PORT` | Defaults to 8000 for HTTP and 8443 when `--https` is enabled. |
 | `--config` | `GHTTP_CONFIG_FILE` | Overrides the default config lookup (`~/.config/ghttp/config.yaml`). |
 | `--bind` | `GHTTP_SERVE_BIND_ADDRESS` | Empty means all interfaces; logs display `localhost` for empty/`0.0.0.0`/`127.0.0.1`. |
-| `--directory` | `GHTTP_SERVE_DIRECTORY` | Defaults to the working directory. |
-| `--protocol` | `GHTTP_SERVE_PROTOCOL` | HTTP/1.0 or HTTP/1.1. |
+| `--directory` | `GHTTP_SERVE_DIRECTORY` | Directory to serve files from. Defaults to the working directory. |
+| `--protocol` | `GHTTP_SERVE_PROTOCOL` | HTTP protocol version (use the full value, for example, `HTTP/1.0` or `HTTP/1.1`). |
 | `--no-md` | `GHTTP_SERVE_NO_MARKDOWN` | Disables Markdown rendering. |
-| `--browse` | `GHTTP_SERVE_BROWSE` | Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
+| `--browse` | `GHTTP_SERVE_BROWSE` | Folder URLs always return a directory listing, even if index.html or README.md exists; direct file requests (including .md) still render normally. Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
 | `--logging-type` | `GHTTP_SERVE_LOGGING_TYPE` | CONSOLE or JSON. |
-| `--proxy` | `GHTTP_SERVE_PROXIES` | Repeatable from=to mapping (for example, `/api=http://backend:8081`); backend can be `http://` or `https://` regardless of frontend scheme; env uses comma-separated list. |
+| `--proxy` | `GHTTP_SERVE_PROXIES` | Enables reverse proxy. Repeatable from=to mapping (for example, `/api=http://backend:8081`); backend can be `http://` or `https://` regardless of frontend scheme; env uses comma-separated list. |
 | `--https` | `GHTTP_SERVE_HTTPS` | Enables self-signed HTTPS using the development certificate authority (SANs from `--https-host`); mutually exclusive with `--tls-cert` and `--tls-key`. |
 | `--https-host` | `GHTTP_HTTPS_HOSTS` | Repeatable flag; env uses comma-separated list; only used with `--https` and included in generated HTTPS certificates. |
 | `--tls-cert` | `GHTTP_SERVE_TLS_CERTIFICATE` | Provide with `--tls-key`; cannot combine with `--https`. |
@@ -84,7 +85,7 @@ Flags map to Viper configuration keys. Environment variables use the `GHTTP_` pr
 
 Legacy single mapping: `--proxy-path` (from) + `--proxy-backend` (to) remain supported when `--proxy`/`GHTTP_SERVE_PROXIES` are unset.
 
-Positional port arguments map to `GHTTP_SERVE_PORT` for `ghttp`.
+Positional port arguments map to `GHTTP_SERVE_PORT` for `ghttp`. When no port is provided, gHTTP defaults to 8000 for HTTP and 8443 when `--https` is enabled.
 
 
 ### Browser trust behaviour

--- a/docs/docker-compose-ai-agents.md
+++ b/docs/docker-compose-ai-agents.md
@@ -12,7 +12,7 @@ The goals are:
 
 - Image: `ghcr.io/temirov/ghttp:latest`
 - Entrypoint: `/app/ghttp`
-- Default listen port: `8000` (overridable)
+- Default listen port: `8000` for HTTP, `8443` when `serve.https` is true
 - Container metadata: `EXPOSE 8080` in the Dockerfile
 - Default serve directory: current working directory (`.` inside `/app`)
 - Configuration sources (highest precedence last):
@@ -57,7 +57,7 @@ The CLI uses Viper with an `env` prefix of `GHTTP` and replaces dots in configur
   - Default: `"."` (the process working directory).
 - `serve.port` → `GHTTP_SERVE_PORT`
   - TCP port that gHTTP listens on inside the container.
-  - Default: `"8000"`.
+  - Default: `"8000"` for HTTP, `"8443"` when `serve.https` is true and no port is provided.
 - `serve.bind_address` → `GHTTP_SERVE_BIND_ADDRESS`
   - Bind address for the HTTP listener.
   - Default: `""` (equivalent to all interfaces).

--- a/docs/docker-compose-ai-agents.md
+++ b/docs/docker-compose-ai-agents.md
@@ -91,8 +91,6 @@ The CLI uses Viper with an `env` prefix of `GHTTP` and replaces dots in configur
 - `https.hosts` → `GHTTP_HTTPS_HOSTS`
   - Comma-separated list of hostnames/IPs included in the dynamic HTTPS certificate.
   - Defaults include `localhost`, `127.0.0.1`, and `::1`.
-- `https.port` → `GHTTP_HTTPS_PORT`
-  - Default HTTPS port used when running `ghttp https serve`.
 
 Additional directory listing control:
 

--- a/docs/docker-compose-ai-agents.md
+++ b/docs/docker-compose-ai-agents.md
@@ -13,7 +13,7 @@ The goals are:
 - Image: `ghcr.io/temirov/ghttp:latest`
 - Entrypoint: `/app/ghttp`
 - Default listen port: `8000` for HTTP, `8443` when `serve.https` is true
-- Container metadata: `EXPOSE 8080` in the Dockerfile
+- Container metadata: `EXPOSE 8000` in the Dockerfile
 - Default serve directory: current working directory (`.` inside `/app`)
 - Configuration sources (highest precedence last):
   - CLI flags (e.g. `--directory`, positional `PORT`)
@@ -24,7 +24,7 @@ For most Compose use cases, prefer environment variables over configuration file
 
 ## Minimal service template
 
-This pattern serves static content from a host directory using HTTP on port `8080`:
+This pattern serves static content from a host directory using HTTP on port `8000`:
 
 ```yaml
 services:
@@ -32,12 +32,12 @@ services:
     image: ghcr.io/temirov/ghttp:latest
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "8000:8000"
     volumes:
       - ./public:/data:ro
     environment:
       GHTTP_SERVE_DIRECTORY: /data
-      GHTTP_SERVE_PORT: "8080"
+      GHTTP_SERVE_PORT: "8000"
       GHTTP_SERVE_LOGGING_TYPE: JSON
 ```
 
@@ -45,7 +45,7 @@ Behavior:
 
 - The container runs `ghttp` as PID 1 with working directory `/app`.
 - `GHTTP_SERVE_DIRECTORY=/data` instructs gHTTP to serve the mounted directory instead of `/app`.
-- `GHTTP_SERVE_PORT=8080` makes gHTTP listen on container port `8080`, matching the Dockerfile `EXPOSE` directive and the Compose port mapping.
+- `GHTTP_SERVE_PORT=8000` makes gHTTP listen on container port `8000`, matching the Dockerfile `EXPOSE` directive and the Compose port mapping.
 - `GHTTP_SERVE_LOGGING_TYPE=JSON` produces structured logs on stdout, which is better for log collection and automated analysis.
 
 ## Configuration via environment variables
@@ -115,13 +115,13 @@ services:
   ghttp:
     image: ghcr.io/temirov/ghttp:latest
     ports:
-      - "8080:8080"
+      - "8000:8000"
     volumes:
       - ./public:/data:ro
     command:
       - --directory
       - /data
-      - "8080"
+      - "8000"
 ```
 
 Notes for agents:
@@ -183,7 +183,7 @@ Use gHTTP as a standalone static file server fronted by a single port. This is t
 
 - A host directory with static assets, mounted into the container (for example, `./public:/data:ro`).
 - `GHTTP_SERVE_DIRECTORY=/data`.
-- A port mapping from host to container (for example, `"8080:8080"` with `GHTTP_SERVE_PORT=8080`).
+- A port mapping from host to container (for example, `"8000:8000"` with `GHTTP_SERVE_PORT=8000`).
 
 ### 2. Sidecar for another service
 

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -22,7 +22,6 @@ const (
 	contextKeyHTTPSCertificateDir  contextKey = "https-certificate-directory"
 
 	defaultServePort       = "8000"
-	defaultHTTPSServePort  = "8443"
 	defaultProtocolVersion = "HTTP/1.1"
 	defaultConfigFileName  = "config"
 	defaultConfigFileType  = "yaml"
@@ -38,7 +37,6 @@ const (
 	flagNameHTTPS              = "https"
 	flagNameBrowse             = "browse"
 	flagNameLoggingType        = "logging-type"
-	flagNameCertificateDir     = "https-cert-dir"
 	flagNameHTTPSHosts         = "https-host"
 	flagNameProxy              = "proxy"
 	flagNameProxyBackend       = "proxy-backend"
@@ -57,7 +55,6 @@ const (
 	configKeyServeLoggingType        = "serve.logging_type"
 	configKeyHTTPSCertificateDir     = "https.certificate_directory"
 	configKeyHTTPSHosts              = "https.hosts"
-	configKeyHTTPSPort               = "https.port"
 	configKeyServeProxies            = "serve.proxies"
 	configKeyProxyBackend            = "serve.proxy_backend"
 	configKeyProxyPathPrefix         = "serve.proxy_path_prefix"
@@ -131,7 +128,6 @@ func Execute(ctx context.Context, arguments []string) int {
 	configurationManager.SetDefault(configKeyConfigFile, "")
 	configurationManager.SetDefault(configKeyHTTPSCertificateDir, filepath.Join(applicationConfigDir, certificates.DefaultCertificateDirectoryName))
 	configurationManager.SetDefault(configKeyHTTPSHosts, []string{"localhost", "127.0.0.1", "::1"})
-	configurationManager.SetDefault(configKeyHTTPSPort, defaultHTTPSServePort)
 	configurationManager.SetDefault(configKeyServeProxies, []string{})
 	configurationManager.SetDefault(configKeyProxyBackend, "")
 	configurationManager.SetDefault(configKeyProxyPathPrefix, "")

--- a/internal/app/application.go
+++ b/internal/app/application.go
@@ -22,6 +22,7 @@ const (
 	contextKeyHTTPSCertificateDir  contextKey = "https-certificate-directory"
 
 	defaultServePort       = "8000"
+	defaultHTTPSServePort  = "8443"
 	defaultProtocolVersion = "HTTP/1.1"
 	defaultConfigFileName  = "config"
 	defaultConfigFileType  = "yaml"
@@ -118,7 +119,6 @@ func Execute(ctx context.Context, arguments []string) int {
 	configurationManager.SetDefault(configKeyServeBindAddress, "")
 	configurationManager.SetDefault(configKeyServeDirectory, ".")
 	configurationManager.SetDefault(configKeyServeProtocol, defaultProtocolVersion)
-	configurationManager.SetDefault(configKeyServePort, defaultServePort)
 	configurationManager.SetDefault(configKeyServeTLSCertificatePath, "")
 	configurationManager.SetDefault(configKeyServeTLSKeyPath, "")
 	configurationManager.SetDefault(configKeyServeNoMarkdown, false)

--- a/internal/app/root_command.go
+++ b/internal/app/root_command.go
@@ -42,8 +42,6 @@ func newRootCommand(resources *applicationResources) *cobra.Command {
 	rootCommand.PersistentFlags().String(flagNameConfigFile, "", "Path to configuration file")
 	_ = resources.configurationManager.BindPFlag(configKeyConfigFile, rootCommand.PersistentFlags().Lookup(flagNameConfigFile))
 
-	rootCommand.AddCommand(newHTTPSCommand(resources, serveFlags, httpsOptionFlags))
-
 	return rootCommand
 }
 

--- a/internal/app/root_command_test.go
+++ b/internal/app/root_command_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
 	"github.com/tyemirov/ghttp/pkg/logging"
@@ -28,20 +27,21 @@ func TestNewRootCommandProvidesHTTPSFlagOnce(t *testing.T) {
 	if rootCommand.Flags().Lookup(flagNameHTTPSHosts) == nil {
 		t.Fatalf("expected https-host flag to be registered")
 	}
+}
 
-	httpsResources := &applicationResources{
-		configurationManager: viper.New(),
+func TestRootCommandDoesNotRegisterHTTPSSubcommand(t *testing.T) {
+	configurationManager := viper.New()
+	resources := &applicationResources{
+		configurationManager: configurationManager,
 		loggingService:       logging.NewTestService(logging.TypeConsole),
 		defaultConfigDirPath: t.TempDir(),
 	}
-	serveFlags := pflag.NewFlagSet("serve", pflag.ContinueOnError)
-	configureServeFlags(serveFlags, httpsResources.configurationManager)
-	httpsOptionFlags := pflag.NewFlagSet("serve-https-options", pflag.ContinueOnError)
-	configureServeHTTPSOptions(httpsOptionFlags, httpsResources.configurationManager)
 
-	httpsCommand := newHTTPSCommand(httpsResources, serveFlags, httpsOptionFlags)
-	if httpsCommand.Use != "https" {
-		t.Fatalf("unexpected https command use: %s", httpsCommand.Use)
+	rootCommand := newRootCommand(resources)
+	for _, subCommand := range rootCommand.Commands() {
+		if subCommand.Name() == "https" {
+			t.Fatalf("unexpected https subcommand registered")
+		}
 	}
 }
 

--- a/internal/app/serve_command.go
+++ b/internal/app/serve_command.go
@@ -78,6 +78,10 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 			}
 		}
 	}
+	enableDynamicHTTPS := configurationManager.GetBool(configKeyServeHTTPS)
+	if !allowTLSFiles {
+		enableDynamicHTTPS = false
+	}
 	absoluteDirectory, absoluteErr := filepath.Abs(directoryPath)
 	if absoluteErr != nil {
 		return fmt.Errorf("resolve directory path: %w", absoluteErr)
@@ -96,7 +100,11 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 	}
 
 	if portValue == "" {
-		portValue = defaultServePort
+		if enableDynamicHTTPS {
+			portValue = defaultHTTPSServePort
+		} else {
+			portValue = defaultServePort
+		}
 	}
 	portNumber, portErr := strconv.Atoi(portValue)
 	if portErr != nil || portNumber <= 0 || portNumber > 65535 {
@@ -107,13 +115,9 @@ func prepareServeConfiguration(cmd *cobra.Command, args []string, portConfigKey 
 	tlsKeyPath := strings.TrimSpace(configurationManager.GetString(configKeyServeTLSKeyPath))
 	markdownDisabled := configurationManager.GetBool(configKeyServeNoMarkdown)
 	browseDirectories := configurationManager.GetBool(configKeyServeBrowse)
-	enableDynamicHTTPS := configurationManager.GetBool(configKeyServeHTTPS)
 	loggingTypeValue, normalizeErr := logging.NormalizeType(configurationManager.GetString(configKeyServeLoggingType))
 	if normalizeErr != nil {
 		return normalizeErr
-	}
-	if !allowTLSFiles {
-		enableDynamicHTTPS = false
 	}
 	if !allowTLSFiles {
 		if tlsCertificatePath != "" || tlsKeyPath != "" {


### PR DESCRIPTION
- Align Dockerfile EXPOSE to 8000 default
- Update README + docker-compose guidance to use 8000