### PR TITLE
Show Quickstart card content on landing page

### DIFF
--- a/docs/assets/css/site.css
+++ b/docs/assets/css/site.css
@@ -491,11 +491,35 @@ h2 {
 
 .detailsSummary {
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   padding: 16px 18px;
   font-family: var(--font-display);
   font-weight: 750;
   letter-spacing: -0.03em;
   list-style: none;
+}
+
+.detailsSummary::after {
+  content: "▾";
+  font-size: 1.1rem;
+  line-height: 1;
+  color: rgba(7, 19, 26, 0.56);
+  transition: transform 140ms ease;
+}
+
+.detailsCard:not([open]) .detailsSummary::after {
+  transform: rotate(-90deg);
+}
+
+.detailsSummary:hover {
+  background: rgba(7, 19, 26, 0.04);
+}
+
+.detailsCard[open] .detailsSummary {
+  border-bottom: 1px solid rgba(7, 19, 26, 0.08);
 }
 
 .detailsSummary::-webkit-details-marker {
@@ -694,4 +718,3 @@ h2 {
     transition: none;
   }
 }
-

--- a/docs/index.html
+++ b/docs/index.html
@@ -236,7 +236,7 @@ docker run -p 8000:8000 -v $(pwd):/data ghcr.io/tyemirov/ghttp:latest --director
               </div>
             </details>
 
-            <details class="detailsCard" role="listitem">
+            <details class="detailsCard" open role="listitem">
               <summary class="detailsSummary">Go toolchain</summary>
               <div class="detailsBody">
                 <p class="muted">
@@ -250,7 +250,7 @@ ghttp</code></pre>
               </div>
             </details>
 
-            <details class="detailsCard" id="download" role="listitem">
+            <details class="detailsCard" id="download" open role="listitem">
               <summary class="detailsSummary">Binary releases</summary>
               <div class="detailsBody">
                 <p class="muted">


### PR DESCRIPTION
Quickstart cards (Go toolchain, Binary releases) were collapsed by default, making them look empty.

Changes
- Open all Quickstart cards by default
- Add a simple expand/collapse affordance (caret + hover + divider)
