### PR TITLE
test(server): fully cover browse index handling and document no-preference semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Flags map to Viper configuration keys. Environment variables use the `GHTTP_` pr
 | `--directory` | `GHTTP_SERVE_DIRECTORY` | Directory to serve files from. Defaults to the working directory. |
 | `--protocol` | `GHTTP_SERVE_PROTOCOL` | HTTP protocol version (use the full value, for example, `HTTP/1.0` or `HTTP/1.1`). |
 | `--no-md` | `GHTTP_SERVE_NO_MARKDOWN` | Disables Markdown rendering. |
-| `--browse` | `GHTTP_SERVE_BROWSE` | Folder URLs always return a directory listing, even if index.html or README.md exists; direct file requests (including .md) still render normally. Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
+| `--browse` | `GHTTP_SERVE_BROWSE` | Folder URLs always return a directory listing, even if index.html or README.md exists. Direct file requests are handled by the same normal file pipeline with no filename preference (including index files); Markdown requests still render when Markdown rendering is enabled. Overrides `GHTTPD_DISABLE_DIR_INDEX`. |
 | `--logging-type` | `GHTTP_SERVE_LOGGING_TYPE` | CONSOLE or JSON. |
 | `--proxy` | `GHTTP_SERVE_PROXIES` | Enables reverse proxy. Repeatable from=to mapping (for example, `/api=http://backend:8081`); backend can be `http://` or `https://` regardless of frontend scheme; env uses comma-separated list. |
 | `--proxy-path` | `GHTTP_SERVE_PROXY_PATH_PREFIX` | Legacy from-path prefix (for example, `/api`); requires `--proxy-backend`. |

--- a/docs/docker-compose-ai-agents.md
+++ b/docs/docker-compose-ai-agents.md
@@ -72,7 +72,8 @@ The CLI uses Viper with an `env` prefix of `GHTTP` and replaces dots in configur
   - Boolean; when truthy, disables Markdown rendering and serves `.md` files as plain assets.
   - Default: `false`.
 - `serve.browse` → `GHTTP_SERVE_BROWSE`
-  - Boolean; when truthy, folder URLs always return a directory listing even if index.html or README.md exists (direct file requests, including .md, still render normally).
+  - Boolean; when truthy, folder URLs always return a directory listing even if index.html or README.md exists.
+  - Direct file requests use the regular file-serving pipeline with no filename preference (including index files); `.md` requests still render when Markdown rendering is enabled.
   - Default: `false`.
 - `serve.logging_type` → `GHTTP_SERVE_LOGGING_TYPE`
   - Logging format: `"CONSOLE"` (human-oriented) or `"JSON"` (machine-oriented).

--- a/internal/server/browse_handler.go
+++ b/internal/server/browse_handler.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"html"
-	"io"
 	"io/fs"
 	"net/http"
 	pathpkg "path"
@@ -85,12 +84,7 @@ func (handler browseHandler) serveDirectFileRequest(responseWriter http.Response
 		return false
 	}
 
-	readSeeker, canSeek := requestedFile.(io.ReadSeeker)
-	if !canSeek {
-		return false
-	}
-
-	http.ServeContent(responseWriter, request, requestedFileInfo.Name(), requestedFileInfo.ModTime(), readSeeker)
+	http.ServeContent(responseWriter, request, requestedFileInfo.Name(), requestedFileInfo.ModTime(), requestedFile)
 	return true
 }
 

--- a/internal/server/browse_handler_test.go
+++ b/internal/server/browse_handler_test.go
@@ -1,0 +1,382 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBrowseHandlerServeDirectFileRequest(t *testing.T) {
+	const defaultTimestamp = "Mon, 02 Jan 2006 15:04:05 GMT"
+	testCases := []struct {
+		name                     string
+		path                     string
+		fileSystem               http.FileSystem
+		expectServed             bool
+		expectBodyContains       string
+		expectBodyNotContains    string
+		expectLastModifiedHeader bool
+	}{
+		{
+			name:         "EmptyPathBypassesDirectServing",
+			path:         "",
+			fileSystem:   testBrowseFileSystem{openFunction: func(path string) (http.File, error) { return nil, errors.New("unexpected open call") }},
+			expectServed: false,
+		},
+		{
+			name:         "TrailingSlashBypassesDirectServing",
+			path:         "/docs/",
+			fileSystem:   testBrowseFileSystem{openFunction: func(path string) (http.File, error) { return nil, errors.New("unexpected open call") }},
+			expectServed: false,
+		},
+		{
+			name: "OpenFailureBypassesDirectServing",
+			path: "/missing.html",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) { return nil, errors.New("open failed") },
+			},
+			expectServed: false,
+		},
+		{
+			name: "StatFailureBypassesDirectServing",
+			path: "/broken.html",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						fileInfo:  testBrowseFileInfo{name: "broken.html", isDirectory: false},
+						statError: errors.New("stat failed"),
+					}, nil
+				},
+			},
+			expectServed: false,
+		},
+		{
+			name: "DirectoryBypassesDirectServing",
+			path: "/folder",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						fileInfo: testBrowseFileInfo{name: "folder", isDirectory: true},
+					}, nil
+				},
+			},
+			expectServed: false,
+		},
+		{
+			name: "MarkdownBypassesDirectServing",
+			path: "/README.md",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						content:  []byte("# README"),
+						fileInfo: testBrowseFileInfo{name: "README.md", isDirectory: false},
+					}, nil
+				},
+			},
+			expectServed: false,
+		},
+		{
+			name: "DirectHtmlIsServed",
+			path: "/index.html",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						content: []byte("<html>Index page</html>"),
+						fileInfo: testBrowseFileInfo{
+							name:         "index.html",
+							isDirectory:  false,
+							modifiedTime: time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC),
+						},
+					}, nil
+				},
+			},
+			expectServed:             true,
+			expectBodyContains:       "Index page",
+			expectBodyNotContains:    "README",
+			expectLastModifiedHeader: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(testingT *testing.T) {
+			handler := browseHandler{
+				next:       http.NotFoundHandler(),
+				fileSystem: testCase.fileSystem,
+			}
+			request := httptest.NewRequest(http.MethodGet, "/placeholder", nil)
+			request.URL.Path = testCase.path
+			recorder := httptest.NewRecorder()
+
+			servedDirectly := handler.serveDirectFileRequest(recorder, request)
+
+			if servedDirectly != testCase.expectServed {
+				testingT.Fatalf("expected servedDirectly=%v, got %v", testCase.expectServed, servedDirectly)
+			}
+			responseBody := recorder.Body.String()
+			if testCase.expectBodyContains != "" && !strings.Contains(responseBody, testCase.expectBodyContains) {
+				testingT.Fatalf("expected body to contain %q, body: %s", testCase.expectBodyContains, responseBody)
+			}
+			if testCase.expectBodyNotContains != "" && strings.Contains(responseBody, testCase.expectBodyNotContains) {
+				testingT.Fatalf("expected body to not contain %q, body: %s", testCase.expectBodyNotContains, responseBody)
+			}
+			lastModifiedHeader := recorder.Header().Get("Last-Modified")
+			if testCase.expectLastModifiedHeader && lastModifiedHeader != defaultTimestamp {
+				testingT.Fatalf("expected Last-Modified %q, got %q", defaultTimestamp, lastModifiedHeader)
+			}
+			if !testCase.expectLastModifiedHeader && lastModifiedHeader != "" {
+				testingT.Fatalf("expected no Last-Modified header, got %q", lastModifiedHeader)
+			}
+		})
+	}
+}
+
+func TestBrowseHandlerServeHTTP(t *testing.T) {
+	type serveHTTPCase struct {
+		name                     string
+		path                     string
+		fileSystem               http.FileSystem
+		expectNextStatus         int
+		expectBodyContains       string
+		expectBodyNotContains    string
+		expectContentTypeHeader  string
+		expectContentTypePresent bool
+	}
+
+	nextStatusCode := http.StatusTeapot
+	testCases := []serveHTTPCase{
+		{
+			name:             "DelegatesNonDirectoryPathToNextHandler",
+			path:             "/missing-file",
+			fileSystem:       testBrowseFileSystem{openFunction: func(path string) (http.File, error) { return nil, errors.New("open failed") }},
+			expectNextStatus: nextStatusCode,
+		},
+		{
+			name:             "DelegatesEmptyPathToNextHandler",
+			path:             "",
+			fileSystem:       testBrowseFileSystem{openFunction: func(path string) (http.File, error) { return nil, errors.New("open failed") }},
+			expectNextStatus: nextStatusCode,
+		},
+		{
+			name: "DelegatesWhenDirectoryOpenFails",
+			path: "/",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) { return nil, errors.New("open failed") },
+			},
+			expectNextStatus: nextStatusCode,
+		},
+		{
+			name: "DelegatesWhenDirectoryStatFails",
+			path: "/",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						fileInfo:  testBrowseFileInfo{name: "/", isDirectory: true},
+						statError: errors.New("stat failed"),
+					}, nil
+				},
+			},
+			expectNextStatus: nextStatusCode,
+		},
+		{
+			name: "DelegatesWhenPathWithSlashIsNotDirectory",
+			path: "/",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						fileInfo: testBrowseFileInfo{name: "file.txt", isDirectory: false},
+					}, nil
+				},
+			},
+			expectNextStatus: nextStatusCode,
+		},
+		{
+			name: "DelegatesWhenDirectoryReadFails",
+			path: "/",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						fileInfo:     testBrowseFileInfo{name: "/", isDirectory: true},
+						readdirError: errors.New("readdir failed"),
+					}, nil
+				},
+			},
+			expectNextStatus: nextStatusCode,
+		},
+		{
+			name: "ServesDirectFileBeforeDirectoryHandling",
+			path: "/index.html",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						content: []byte("<html>Index page</html>"),
+						fileInfo: testBrowseFileInfo{
+							name:        "index.html",
+							isDirectory: false,
+						},
+					}, nil
+				},
+			},
+			expectBodyContains:    "Index page",
+			expectBodyNotContains: "next-handler",
+		},
+		{
+			name: "RendersDirectoryListingWhenDirectoryReadable",
+			path: "/",
+			fileSystem: testBrowseFileSystem{
+				openFunction: func(path string) (http.File, error) {
+					return &testBrowseFile{
+						fileInfo: testBrowseFileInfo{name: "/", isDirectory: true},
+						readdirEntries: []fs.FileInfo{
+							testBrowseFileInfo{name: "zeta.txt", isDirectory: false},
+							testBrowseFileInfo{name: "alpha", isDirectory: true},
+						},
+					}, nil
+				},
+			},
+			expectBodyContains:       "href=\"/alpha/\"",
+			expectBodyNotContains:    "next-handler",
+			expectContentTypeHeader:  "text/html; charset=utf-8",
+			expectContentTypePresent: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(testingT *testing.T) {
+			nextHandler := http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
+				responseWriter.WriteHeader(nextStatusCode)
+				_, _ = responseWriter.Write([]byte("next-handler"))
+			})
+			handler := browseHandler{
+				next:       nextHandler,
+				fileSystem: testCase.fileSystem,
+			}
+			request := httptest.NewRequest(http.MethodGet, "/placeholder", nil)
+			request.URL.Path = testCase.path
+			recorder := httptest.NewRecorder()
+
+			handler.ServeHTTP(recorder, request)
+
+			if testCase.expectNextStatus != 0 && recorder.Code != testCase.expectNextStatus {
+				testingT.Fatalf("expected delegated status %d, got %d", testCase.expectNextStatus, recorder.Code)
+			}
+			responseBody := recorder.Body.String()
+			if testCase.expectBodyContains != "" && !strings.Contains(responseBody, testCase.expectBodyContains) {
+				testingT.Fatalf("expected body to contain %q, body: %s", testCase.expectBodyContains, responseBody)
+			}
+			if testCase.expectBodyNotContains != "" && strings.Contains(responseBody, testCase.expectBodyNotContains) {
+				testingT.Fatalf("expected body to not contain %q, body: %s", testCase.expectBodyNotContains, responseBody)
+			}
+			contentTypeHeader := recorder.Header().Get("Content-Type")
+			if testCase.expectContentTypePresent && contentTypeHeader != testCase.expectContentTypeHeader {
+				testingT.Fatalf("expected content type %q, got %q", testCase.expectContentTypeHeader, contentTypeHeader)
+			}
+		})
+	}
+}
+
+type testBrowseFileSystem struct {
+	openFunction func(path string) (http.File, error)
+}
+
+func (fileSystem testBrowseFileSystem) Open(path string) (http.File, error) {
+	return fileSystem.openFunction(path)
+}
+
+type testBrowseFile struct {
+	content        []byte
+	currentOffset  int64
+	fileInfo       fs.FileInfo
+	statError      error
+	readdirEntries []fs.FileInfo
+	readdirError   error
+}
+
+func (file *testBrowseFile) Close() error {
+	return nil
+}
+
+func (file *testBrowseFile) Read(buffer []byte) (int, error) {
+	if file.currentOffset >= int64(len(file.content)) {
+		return 0, io.EOF
+	}
+	readCount := copy(buffer, file.content[file.currentOffset:])
+	file.currentOffset += int64(readCount)
+	return readCount, nil
+}
+
+func (file *testBrowseFile) Seek(offset int64, whence int) (int64, error) {
+	switch whence {
+	case io.SeekStart:
+		file.currentOffset = offset
+	case io.SeekCurrent:
+		file.currentOffset += offset
+	case io.SeekEnd:
+		file.currentOffset = int64(len(file.content)) + offset
+	default:
+		return 0, errors.New("invalid whence")
+	}
+	if file.currentOffset < 0 {
+		return 0, errors.New("negative position")
+	}
+	return file.currentOffset, nil
+}
+
+func (file *testBrowseFile) Readdir(count int) ([]fs.FileInfo, error) {
+	if file.readdirError != nil {
+		return nil, file.readdirError
+	}
+	return file.readdirEntries, nil
+}
+
+func (file *testBrowseFile) Stat() (fs.FileInfo, error) {
+	if file.statError != nil {
+		return nil, file.statError
+	}
+	return file.fileInfo, nil
+}
+
+type testBrowseFileInfo struct {
+	name         string
+	size         int64
+	mode         fs.FileMode
+	modifiedTime time.Time
+	isDirectory  bool
+}
+
+func (fileInfo testBrowseFileInfo) Name() string {
+	return fileInfo.name
+}
+
+func (fileInfo testBrowseFileInfo) Size() int64 {
+	return fileInfo.size
+}
+
+func (fileInfo testBrowseFileInfo) Mode() fs.FileMode {
+	if fileInfo.mode != 0 {
+		return fileInfo.mode
+	}
+	if fileInfo.isDirectory {
+		return fs.ModeDir | 0o755
+	}
+	return 0o644
+}
+
+func (fileInfo testBrowseFileInfo) ModTime() time.Time {
+	if fileInfo.modifiedTime.IsZero() {
+		return time.Unix(0, 0).UTC()
+	}
+	return fileInfo.modifiedTime
+}
+
+func (fileInfo testBrowseFileInfo) IsDir() bool {
+	return fileInfo.isDirectory
+}
+
+func (fileInfo testBrowseFileInfo) Sys() interface{} {
+	return nil
+}

--- a/internal/server/file_server_test.go
+++ b/internal/server/file_server_test.go
@@ -225,6 +225,7 @@ func TestIntegrationFileServerBrowseModeRendersMarkdownOnDirectRequest(t *testin
 
 func TestIntegrationFileServerBrowseModeServesHtmlOnDirectRequest(t *testing.T) {
 	temporaryDirectory := t.TempDir()
+	writeFile(t, filepath.Join(temporaryDirectory, "index.html"), "<html><body>Root index page</body></html>")
 	exampleDirectory := filepath.Join(temporaryDirectory, "example")
 	mustMkDir(t, exampleDirectory)
 	writeFile(t, filepath.Join(exampleDirectory, "index.html"), "<html><body>Index page</body></html>")
@@ -236,6 +237,7 @@ func TestIntegrationFileServerBrowseModeServesHtmlOnDirectRequest(t *testing.T) 
 		requestPath  string
 		expectedText string
 	}{
+		{requestPath: "/index.html", expectedText: "Root index page"},
 		{requestPath: "/example/index.html", expectedText: "Index page"},
 		{requestPath: "/example/hello.html", expectedText: "Hello page"},
 	}

--- a/internal/server/file_server_test.go
+++ b/internal/server/file_server_test.go
@@ -293,6 +293,78 @@ func TestIntegrationFileServerBrowseModeListsRootDirectory(t *testing.T) {
 	}
 }
 
+func TestIntegrationFileServerBrowseModeIndexHTMLUseCases(t *testing.T) {
+	temporaryDirectory := t.TempDir()
+	rootIndexContent := "<html><body>Root index page</body></html>"
+	nestedIndexContent := "<html><body>Example index page</body></html>"
+	writeFile(t, filepath.Join(temporaryDirectory, "index.html"), rootIndexContent)
+	exampleDirectory := filepath.Join(temporaryDirectory, "example")
+	mustMkDir(t, exampleDirectory)
+	writeFile(t, filepath.Join(exampleDirectory, "index.html"), nestedIndexContent)
+
+	handler := newTestFileServerHandler(temporaryDirectory, true, false, true, "")
+
+	assertDirectoryListingResponse := func(testingT *testing.T, requestPath string, expectedLink string, unexpectedText string) {
+		testingT.Helper()
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, requestPath, nil)
+		handler.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			testingT.Fatalf("request %s expected 200 status, got %d", requestPath, recorder.Code)
+		}
+		bodyBytes, readErr := io.ReadAll(recorder.Result().Body)
+		if readErr != nil {
+			testingT.Fatalf("request %s read body: %v", requestPath, readErr)
+		}
+		responseBody := string(bodyBytes)
+		if !strings.Contains(responseBody, expectedLink) {
+			testingT.Fatalf("request %s expected listing link %q, body: %s", requestPath, expectedLink, responseBody)
+		}
+		if strings.Contains(responseBody, unexpectedText) {
+			testingT.Fatalf("request %s expected directory listing instead of index content %q, body: %s", requestPath, unexpectedText, responseBody)
+		}
+	}
+
+	assertDirectFileResponse := func(testingT *testing.T, requestPath string, expectedText string) {
+		testingT.Helper()
+		recorder := httptest.NewRecorder()
+		request := httptest.NewRequest(http.MethodGet, requestPath, nil)
+		handler.ServeHTTP(recorder, request)
+
+		if recorder.Code != http.StatusOK {
+			testingT.Fatalf("request %s expected 200 status, got %d", requestPath, recorder.Code)
+		}
+		if recorder.Header().Get("Location") != "" {
+			testingT.Fatalf("request %s expected no redirect location header, got %q", requestPath, recorder.Header().Get("Location"))
+		}
+		bodyBytes, readErr := io.ReadAll(recorder.Result().Body)
+		if readErr != nil {
+			testingT.Fatalf("request %s read body: %v", requestPath, readErr)
+		}
+		responseBody := string(bodyBytes)
+		if !strings.Contains(responseBody, expectedText) {
+			testingT.Fatalf("request %s expected index content %q, body: %s", requestPath, expectedText, responseBody)
+		}
+	}
+
+	t.Run("RootDirectoryListsIndexLink", func(testingT *testing.T) {
+		assertDirectoryListingResponse(testingT, "/", "href=\"/index.html\"", "Root index page")
+	})
+
+	t.Run("RootIndexFileServesDirectly", func(testingT *testing.T) {
+		assertDirectFileResponse(testingT, "/index.html", "Root index page")
+	})
+
+	t.Run("NestedDirectoryListsIndexLink", func(testingT *testing.T) {
+		assertDirectoryListingResponse(testingT, "/example/", "href=\"/example/index.html\"", "Example index page")
+	})
+
+	t.Run("NestedIndexFileServesDirectly", func(testingT *testing.T) {
+		assertDirectFileResponse(testingT, "/example/index.html", "Example index page")
+	})
+}
+
 func TestIntegrationFileServerServesInitialHtmlFileAtRoot(t *testing.T) {
 	temporaryDirectory := t.TempDir()
 	writeFile(t, filepath.Join(temporaryDirectory, "cat.html"), "<html><body>Cat</body></html>")


### PR DESCRIPTION
## Summary
- add a dedicated integration suite for `index.html` behavior in `--browse` mode
- add a new `browse_handler` test suite that drives `internal/server/browse_handler.go` to 100% statement coverage
- simplify `browse_handler` by removing an unreachable `io.ReadSeeker` assertion while keeping behavior unchanged
- document `--browse` semantics explicitly: direct file requests use the normal pipeline with no filename preference (including `index.html`)

## Validation
- go fmt ./...
- go vet ./...
- go test ./...
- go test ./internal/server -coverprofile=/tmp/server.cover.out
- go tool cover -func=/tmp/server.cover.out (browse_handler.go functions at 100%)