### PR TITLE
Serve index files when directory listing is disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ After installation the `ghttp` binary is placed in `$GOBIN` (or `$GOPATH/bin`). 
 * Issue SAN-aware leaf certificates on demand whenever HTTPS is enabled, covering `localhost`, `127.0.0.1`, `::1`, and additional hosts supplied via repeated `--https-host` flags or Viper configuration.
 * Render Markdown files (`*.md`) to HTML automatically, treat `README.md` as a directory landing page, and skip the feature entirely with `--no-md` or `serve.no_markdown: true` in configuration.
 * When Firefox is installed, automatically configure its profiles to trust the generated certificates so browser warnings disappear on the next restart.
-* Suppress automatic directory listings by exporting `GHTTPD_DISABLE_DIR_INDEX=1`; the handler returns HTTP 403 for directory roots.
+* Suppress automatic directory listings by exporting `GHTTPD_DISABLE_DIR_INDEX=1`; directory roots still serve `index.html` / `index.htm` when present, otherwise the handler returns HTTP 403.
 * Apply route-scoped response headers (including `Cache-Control`) with repeatable `--response-header /path=Header-Name:Header-Value` mappings.
 * Configure proxy streaming mode per route using `--proxy-streaming /path=unbuffered|buffered` to control proxy flush behavior.
 * Configure every flag via `~/.config/ghttp/config.yaml` or environment variables prefixed with `GHTTP_` (for example, `GHTTP_SERVE_DIRECTORY=/srv/www`).

--- a/internal/server/initial_file_handler.go
+++ b/internal/server/initial_file_handler.go
@@ -28,11 +28,15 @@ func (handler initialFileHandler) ServeHTTP(responseWriter http.ResponseWriter, 
 		handler.next.ServeHTTP(responseWriter, request)
 		return
 	}
+	handler.next.ServeHTTP(responseWriter, rewriteRequestPath(request, handler.initialRequestPath))
+}
+
+func rewriteRequestPath(request *http.Request, requestPath string) *http.Request {
 	clonedRequest := request.Clone(request.Context())
 	urlCopy := *request.URL
-	urlCopy.Path = handler.initialRequestPath
-	urlCopy.RawPath = handler.initialRequestPath
+	urlCopy.Path = requestPath
+	urlCopy.RawPath = requestPath
 	clonedRequest.URL = &urlCopy
-	clonedRequest.RequestURI = handler.initialRequestPath
-	handler.next.ServeHTTP(responseWriter, clonedRequest)
+	clonedRequest.RequestURI = requestPath
+	return clonedRequest
 }

--- a/internal/server/markdown_handler.go
+++ b/internal/server/markdown_handler.go
@@ -153,10 +153,15 @@ func (handler markdownHandler) selectMarkdownCandidate(directoryPath string) (st
 }
 
 func (handler markdownHandler) directoryIndexExists(directoryPath string) bool {
+	_, exists := findDirectoryIndexPath(handler.fileSystem, directoryPath)
+	return exists
+}
+
+func findDirectoryIndexPath(fileSystem http.FileSystem, directoryPath string) (string, bool) {
 	for index := range directoryIndexCandidates {
 		candidateName := directoryIndexCandidates[index]
 		candidatePath := pathpkg.Join(directoryPath, candidateName)
-		fileHandle, openErr := handler.fileSystem.Open(candidatePath)
+		fileHandle, openErr := fileSystem.Open(candidatePath)
 		if openErr != nil {
 			continue
 		}
@@ -168,9 +173,9 @@ func (handler markdownHandler) directoryIndexExists(directoryPath string) bool {
 		if candidateInfo.IsDir() {
 			continue
 		}
-		return true
+		return candidatePath, true
 	}
-	return false
+	return "", false
 }
 
 func buildHTMLDocument(title string, body []byte) []byte {
@@ -187,9 +192,13 @@ func isMarkdownFile(fileName string) bool {
 	return strings.EqualFold(filepath.Ext(fileName), ".md")
 }
 
-func newDirectoryGuardHandler(next http.Handler, _ http.FileSystem) http.Handler {
+func newDirectoryGuardHandler(next http.Handler, fileSystem http.FileSystem) http.Handler {
 	return http.HandlerFunc(func(responseWriter http.ResponseWriter, request *http.Request) {
 		if strings.HasSuffix(request.URL.Path, "/") {
+			if _, exists := findDirectoryIndexPath(fileSystem, request.URL.Path); exists {
+				next.ServeHTTP(responseWriter, request)
+				return
+			}
 			http.Error(responseWriter, errorMessageDirectoryListingDisabled, http.StatusForbidden)
 			return
 		}

--- a/tests/integration/full_coverage_integration_test.go
+++ b/tests/integration/full_coverage_integration_test.go
@@ -522,9 +522,17 @@ func exerciseStandardHTTPServerFlows(testingT *testing.T, repositoryRoot string,
 		false,
 	)
 	disabledClient := &http.Client{Timeout: browseModeRequestTimeout}
-	rootStatusCode, _, _ := executeHTTPGet(testingT, disabledClient, disabledBaseURL, "/")
-	if rootStatusCode != http.StatusForbidden {
-		testingT.Fatalf("expected forbidden listing with no markdown and disabled directory listing, got %d", rootStatusCode)
+	rootStatusCode, _, rootBody := executeHTTPGet(testingT, disabledClient, disabledBaseURL, "/")
+	if rootStatusCode != http.StatusOK || !strings.Contains(rootBody, "ROOT INDEX") {
+		testingT.Fatalf("expected root index serving with no markdown and disabled directory listing, got status=%d body=%s", rootStatusCode, rootBody)
+	}
+	nestedStatusCode, _, nestedBody := executeHTTPGet(testingT, disabledClient, disabledBaseURL, "/example/")
+	if nestedStatusCode != http.StatusOK || !strings.Contains(nestedBody, "NESTED INDEX") {
+		testingT.Fatalf("expected nested index serving with no markdown and disabled directory listing, got status=%d body=%s", nestedStatusCode, nestedBody)
+	}
+	missingIndexStatusCode, _, _ := executeHTTPGet(testingT, disabledClient, disabledBaseURL, "/docs/")
+	if missingIndexStatusCode != http.StatusForbidden {
+		testingT.Fatalf("expected forbidden listing without index file in no-markdown mode, got %d", missingIndexStatusCode)
 	}
 	if stopErr := disabledServer.stop(); stopErr != nil {
 		testingT.Fatalf("stop no-markdown server: %v", stopErr)


### PR DESCRIPTION
## Summary
- allow directory requests in no-markdown mode to fall through to file serving when index.html or index.htm exists
- keep returning 403 for directory requests with no index file when GHTTPD_DISABLE_DIR_INDEX=1 is set
- update the integration coverage test and README to reflect the new behavior

## Testing
- make ci
